### PR TITLE
Reserve old cryptosuite value range.

### DIFF
--- a/index.html
+++ b/index.html
@@ -747,19 +747,15 @@ These will be registered on a first-come first-serve basis.
           <td>Data Integrity v2.0</td>
         </tr>
         <tr>
-          <td><code>0x34</code></td>
-          <td><code>ecdsa-rdfc-2019</code></td>
-          <td>Data Integrity ECDSA RDFC 2019 cryptosuite identifier</td>
-        </tr>
-        <tr>
-          <td><code>0x35</code></td>
-          <td><code>ecdsa-sd-2023</code></td>
-          <td>Data Integrity ECDSA-SD 2023 cryptosuite identifier</td>
-        </tr>
-        <tr>
-          <td><code>0x36</code></td>
-          <td><code>eddsa-rdfc-2022</code></td>
-          <td>Data Integrity EDDSA RDFC 2022 cryptosuite identifier</td>
+          <!--
+            This range was prior experimental use for Data Integrity
+            cryptosuite identifiers. It is expected this range will be made
+            available at some future point unless the values were determined
+            to be in active use.
+          -->
+          <td><code>0x34 - 0x36</code></td>
+          <td><code>RESERVED</code></td>
+          <td>Reserved for future use.</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
The Data Integrity cryptosuite identifier values were an experimental use that was abandoned in favor of another technique. The value range is being reserved in case anyone happened to have used those values. If no feedback is received about this change, the range will be freed at some point in the future.

Fixes: https://github.com/json-ld/cbor-ld-spec/issues/25


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/cbor-ld-spec/pull/26.html" title="Last updated on Jun 27, 2024, 9:44 PM UTC (e93d2c9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/cbor-ld-spec/26/4edf4bc...e93d2c9.html" title="Last updated on Jun 27, 2024, 9:44 PM UTC (e93d2c9)">Diff</a>