### PR TITLE
Add VCDM v2 context value.

### DIFF
--- a/index.html
+++ b/index.html
@@ -722,7 +722,12 @@ These will be registered on a first-come first-serve basis.
           <td>Verifiable Credentials Status List</td>
         </tr>
         <tr>
-          <td><code>0x21 - 0x2F</code></td>
+          <td><code>0x21</code></td>
+          <td><code>https://www.w3.org/ns/credentials/v2</code></td>
+          <td>Verifiable Credentials Data Model v2</td>
+        </tr>
+        <tr>
+          <td><code>0x22 - 0x2F</code></td>
           <td></td>
           <td>Available for use.</td>
         </tr>


### PR DESCRIPTION
Add Verifiable Credentials Data Model (VCDM) v2 context value.

https://www.w3.org/TR/vc-data-model-2.0/#base-context

This context is still a work in progress, but the URL should be stable enough for use here.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/cbor-ld-spec/pull/27.html" title="Last updated on Jun 28, 2024, 1:11 AM UTC (4e21555)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/cbor-ld-spec/27/a45b715...4e21555.html" title="Last updated on Jun 28, 2024, 1:11 AM UTC (4e21555)">Diff</a>