### PR TITLE
Add support for different CBOR tags to be used for CBOR-LD to identify required application context maps.

### DIFF
--- a/index.html
+++ b/index.html
@@ -447,18 +447,18 @@ The first step in decoding a CBOR-LD payload is to recreate the term codec
 map that was used to encode it by processing the contexts in the payload. However,
 the contexts needed to create the term codec map can have their URLs encoded as integers
 by CBOR-LD. If a CBOR-LD payload contains context URLs compressed in such a way, the
-consumer of the CBOR-LD must know what compression tables (maps from JSON-LD terms to integers)
-was used to compress the context URLs during creation to be able to reconstruct the term codec
+consumer of the CBOR-LD needs to know what compression tables (maps from JSON-LD terms to integers)
+were used to compress the context URLs during creation to be able to reconstruct the term codec
 map. The following sections define the exact mechanism by which this can be accomplished, allowing 
-an arbitrary CBOR-LD consumer to decompress any CBOR-LD payload meeting this specification.
+an arbitrary CBOR-LD consumer to decompress any CBOR-LD payload that conforms to this specification.
     </p>
     <p>
 To this end, we have registered the range of CBOR tags 1536-1791** (0x0600-0x06FF) to be used for CBOR-LD,
 where data that includes tag value is used to lookup what compression table(s) are needed
 to decompress the CBOR-LD context URLs.
     </p>
-    <p>
-<b>**Note:</b> this exact range of tag values has not yet been officially registered with
+    <p class="issue">
+This exact range of tag values has not yet been officially registered with
 <a href="https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml">the IANA CBOR
 Tag Registry</a>. The exact range is subject to change.
     </p>
@@ -496,7 +496,7 @@ Registry Entry Value: a positive integer.
 Use Case: what type of CBOR-LD payload this entry is used for.
           </li>
           <li>
-`typeTables`: an array containing what `Type Tables` must be used for this
+`typeTables`: an array containing what `Type Tables` are to be used for this
 type of payload.
           </li>
           <li>

--- a/index.html
+++ b/index.html
@@ -447,14 +447,14 @@ The first step in decoding a CBOR-LD payload is to recreate the term codec
 map that was used to encode it by processing the contexts in the payload. However,
 the contexts needed to create the term codec map can have their URLs encoded as integers
 by CBOR-LD. If a CBOR-LD payload contains context URLs compressed in such a way, the
-consumer of the CBOR-LD must know what `Compression Table` (map from JSON-LD terms to integers)
+consumer of the CBOR-LD must know what compression tables (maps from JSON-LD terms to integers)
 was used to compress the context URLs during creation to be able to reconstruct the term codec
 map. The following sections define the exact mechanism by which this can be accomplished, allowing 
 an arbitrary CBOR-LD consumer to decompress any CBOR-LD payload meeting this specification.
     </p>
     <p>
 To this end, we have registered the range of CBOR tags 1536-1791** (0x0600-0x06FF) to be used for CBOR-LD,
-where data that includes tag value is used to lookup what `Compression Table`(s) are needed
+where data that includes tag value is used to lookup what compression table(s) are needed
 to decompress the CBOR-LD context URLs.
     </p>
     <p>
@@ -466,7 +466,7 @@ Tag Registry</a>. The exact range is subject to change.
       <h2>CBOR-LD Varint</h2>
       <p>
 To enable unbounded extension on possible use cases for CBOR-LD that require different
-`Compression Table` material for consumption while working within a fixed number of
+compression table material for consumption while working within a fixed number of
 CBOR tag values, we define the following.
       </p>
       <p>
@@ -588,57 +588,6 @@ The following is the current CBOR-LD registry:
       </table>
 
     </section>
-
-    <section class="informative">
-      <h2>CBOR Varint Registry Example</h2>
-      <p>
-As as example, take th one-entry <b>CBOR-LD Varint Registry</b>:
-      </p>
-      <table class="simple">
-        <thead>
-          <tr>
-            <th>Value</th>
-            <th>Use Case</th>
-            <th>contextTables</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-          <td>100</td>
-          <td>Specification Example</td>
-          <td>["https://example.cborld.com/table1", "https://example.cborld.com/table2"]</td>
-          </tr>
-        </tbody>
-      </table>
-      <p>
-Dereferencing "https://example.cborld.com/table1" might then return:
-      </p>
-      <pre class="example nohighlight"
-             title="Example results derefencing contextTables entries">
-{
-  "contextCompressionMap":
-    {
-      "https://w3id.org/ns/credentials/v2": 32900,
-      "https://example.cborld.com/context1": 32901
-    },
-  "contextDecompressionMap":
-    {
-      32900: "https://w3id.org/ns/credentials/v2",
-      32901: "https://example.cborld.com/context1"
-    },
-  "termCompressionMap":
-    {
-      "ecdsa-xi-2023": 35000,
-      "ecdsa-rdfc-2019": 35001
-    },
-  "termDecompressionMap":
-    {
-      35000: "ecdsa-xi-2023",
-      35001: "ecdsa-rdfc-2019"
-    }
-}
-        </pre>
-    </section>
   </section>
 
   <section class="normative">
@@ -689,15 +638,15 @@ and `varintBytesValue` as `options.varintBytesValue`.
       <h2>Uncompressed CBOR-LD Buffer Algorithm</h2>
 
       <p>
-This algorithm takes a JSON-LD object `jsonldDocument` and `options` as
-input.
+This algorithm takes a JSON-LD object `jsonldDocument`, integer `registryValue` and 
+`options` as input.
       </p>
 
       <ol>
         <li>Let `result` be an empty CBOR-encoded byte array.</li>
         <li>
-Set the first two bytes (CBOR Tag) to 0x0500 (CBOR-LD - 0x05, Uncompressed -
-0x00, Tag 1280))
+Set the first two bytes (CBOR Tag) to 0x0600 (CBOR-LD - 0x06, Uncompressed -
+0x00)
         </li>
         <li>
 For every key-value in the map, generate the Uncompressed CBOR-LD
@@ -875,7 +824,10 @@ Return {varintTagValue, varintBytesValue}.
 
   <section class="appendix">
     <h1>Term Codec Registry</h1>
-
+    <p>
+<b>**Note:</b> This term codec registry is deprecated and has been replaced by the CBOR-LD
+Varint Registry.
+    </p>
     <p>
 The following is a registry of well-known term codecs.
 These will be registered on a first-come first-serve basis.

--- a/index.html
+++ b/index.html
@@ -648,14 +648,14 @@ Dereferencing "https://example.cborld.com/table1" might then return:
 
       <p>
 This algorithm takes JSON-LD objects `jsonldDocument` and `options` as well 
-as an integer `varintValue` as input.
+as an integer `registryValue` as input.
       </p>
 
       <ol>
         <li>Let `result` be an empty CBOR-encoded byte array.</li>
         <li>
 Set {`varintTagValue`, `varintBytesValue`} to the return value of the "Get CBOR-LD Varint Structure
-Algorithm", passing `varintValue` as input.
+Algorithm", passing `registryValue` as input.
         </li>
         <li>
 If the "Get CBOR-LD Varint Structure Algorithm" resulted in an error, set `result` to the
@@ -665,22 +665,20 @@ return value of the "Generate Uncompressed CBOR-LD Algorithm".
 Otherwise:
           <ol>
             <li>
-Initialize `contextUrlMap` and `termMap` to empty maps.
+Initialize `typeTables`
             </li>
             <li>
-For each entry in the `contextTables` array in the <b>CBOR-LD Varint Registry Entry</b> 
-associated with `varintValue`, dereference the URL and add all entries in the
-`contextCompressionMap` map in the resulting document to `contextUrls`. If "callerProvidedTable"
+For each entry in the `typeTables` array in the <b>CBOR-LD Varint Registry Entry</b> 
+associated with `registryValue`, dereference the URL if necessary and add ${type}: ${table} from
+the resulting document to `typeTables`. If "callerProvidedTable"
 appears in `contextTables`, populate `contextUrls` with `options.callerProvidedTable` as well.
-Then, add all entries in `termCompressionMap` to `termMap`.
             </li>
             <li>
 Set `result` to the return value of the "Generate Compressed CBOR-LD
-Algorithm" passing `contextUrls` as `options.contextUrls`, `termMap` as `options.termMap`,
-`varintTagValue` as `options.varintTagValue`, and `varintBytesValue`
-as `options.varintBytesValue`.
+Algorithm" passing `typeTables` as `options.typeTable`, `varintTagValue` as `options.varintTagValue`,
+and `varintBytesValue` as `options.varintBytesValue`.
             </li>
-            
+
           </ol>
 
         <li>Return `result`.</li>
@@ -718,14 +716,10 @@ This algorithm takes a JSON-LD object `jsonldDocument` and `options` as input.
 The `options` MUST contain:
       </p>
       <dl>
-        <dt>`contextUrls`</dt>
+        <dt>`typeTables`</dt>
         <dd>
-A map of JSON-LD context URL strings that are mapped to
-their encoded CBOR-LD values.
-        </dd>
-        <dt>`termMap`</dt>
-        <dd>
-A map of JSON-LD terms and their associated CBOR-LD term codecs.
+A map of JSON-LD types to maps. Each of these maps will map values of the associated
+type to their encoded CBOR-LD values.
         </dd>
         <dt>`varintTagValue`</dt>
         <dd>
@@ -778,7 +772,7 @@ function.
       <h2>Get Term Codec Map Algorithm</h2>
 
       <p>
-This algorithm takes two maps `contextUrls` and `termMap` and returns a CBOR-LD
+This algorithm takes a map `typeTable` and returns a CBOR-LD
 term codec map that maps JSON-LD terms to their associated byte values
 and value compression functions.
       </p>
@@ -796,10 +790,11 @@ every entry.
 The first entry should be set to `value` with an undefined value.
                 </li>
                 <li>
-Let `compressor` be a known global compressor function associated with the
-`@type` property, a compressor for this entry provided in `termMap`,
-function, or the generic CBOR compressor function, which returns the bytes
-associated with a typical CBOR compression of the given datatype.
+Let `compressor` be a known compressor function associated with the
+`@type` property from `typeTable`, a type-specific generic compressor
+associated with the processing model in use, or the generic CBOR compressor 
+function, which returns the bytes associated with a typical CBOR compression
+of the given datatype.
                 </li>
               </ol>
             </li>
@@ -842,34 +837,36 @@ error.
     </section>
     <section>
       <h3>Get CBOR-LD Varint Structure Algorithm</h3>
-  This algorithm takes as input an integer `varintValue`.
+This algorithm takes as input an integer `registryValue`.
       <ol>
         <li>
-  If `varintValue` is less than 128:
+If `registryValue` is less than 128:
           <ol>
             <li>
-              Set `varintEncoded` to the byte encoding of `varintValue.
+Set `varintEncoded` to the byte encoding of `registryValue`.
             </li>
             <li>
-    Set `varintTagValue` to the result of appending `varintEncoded` to the end of the bytes
-    0xD906, and set `varintBytesValue` to `null`.
+Set `varintTagValue` to the result of appending `varintEncoded` to the end of the bytes
+0xD906, and set `varintBytesValue` to `null`.
             </li>
           </ol>
         </li>
         <li>
-  Otherwise:
+Otherwise:
           <ol>
             <li>
-  Set `varintTagValue` to 0xD90680.
+Set `varintArray` to an array containing the varint representation of `registryValue`.
             </li>
             <li>
-  Set `varintBytesValue` to a CBOR major type 2 bytes object containing a varint representation
-  of `varintValue`.
+Set `varintTagValue` to `varintArray[0]` appended to the end of the bytes 0xD906.
+            </li>
+            <li>
+Set `varintBytesValue` to a CBOR array containing the rest of `varintArray`.
             </li>
           </ol>
         </li>
         <li>
-  Return {varintTagValue, varintBytesValue}.
+Return {varintTagValue, varintBytesValue}.
         </li>
       </ol>
     </section>

--- a/index.html
+++ b/index.html
@@ -471,7 +471,7 @@ CBOR tag values, we define the following.
       </p>
       <p>
 Implementers MUST interpret the last byte of the two-byte CBOR tag value on a CBOR-LD payload
-as the beginning of a varint. If the CBOR tag is in the range (0x0600-0x067F), the last byte of
+as the beginning of a varint. If the CBOR tag is in the range `0x0600`–`0x067F`, the last byte of
 the CBOR tag is a one-byte varint. If the CBOR tag is `0x0680` or greater, the first item in the
 CBOR payload MUST be a major type 2 byte string containing the rest of the varint. See Algorithm <a
 href="#get-cbor-ld-varint-structure-algorithm"></a> for

--- a/index.html
+++ b/index.html
@@ -441,6 +441,30 @@ term.
   </section>
 
   <section class="normative">
+    <h1>CBOR Tags for CBOR-LD</h1>
+    <p>
+The first step in decoding a CBOR-LD payload is to recreate the term codec
+map that was used to encode it by processing the contexts in the payload. However,
+as these context URLs are encoded as integers, the consumer of the CBOR-LD
+must know what `Application Context Table` (map from URL to integer) was used in
+its creation to be able to reconstruct the term codec map.
+    </p>
+    <p>
+To this end, we have registered the range of CBOR tags 1500-1800** to be used for CBOR-LD,
+where tag values are used to lookup what `Application Context Table`(s) should be used
+to decompress the CBOR-LD context URLs.
+    </p>
+    <p>
+<b>**Note:</b> this exact range of tag values has not yet been officially registered with
+<a href="https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml">the IANA CBOR
+Tag Registry</a>. The exact range is subject to change.
+    </p>
+    <section>
+      <h2>CBOR-LD </h2>
+    </section>
+  </section>
+
+  <section class="normative">
     <h1>Algorithms</h1>
     <section>
       <h2>JSON-LD to CBOR-LD Algorithm</h2>

--- a/index.html
+++ b/index.html
@@ -446,14 +446,14 @@ term.
 The first step in decoding a CBOR-LD payload is to recreate the term codec
 map that was used to encode it by processing the contexts in the payload. However,
 as these context URLs are encoded as integers, the consumer of the CBOR-LD
-must know what `Application Context Table` (map from URL to integer) was used in
+must know what `Application Context Table` (map from context URLs to integers) was used in
 its creation to be able to reconstruct the term codec map. The following sections
 define the exact mechanism by which this can be accomplished, allowing an arbitrary
 CBOR-LD consumer to decompress any CBOR-LD payload meeting this specification.
     </p>
     <p>
 To this end, we have registered the range of CBOR tags 1500-1800** to be used for CBOR-LD,
-where data that includes tag value is used to lookup what `Application Context Table`(s) should be used
+where data that includes tag value is used to lookup what `Application Context Table`(s) are needed
 to decompress the CBOR-LD context URLs.
     </p>
     <p>
@@ -573,24 +573,40 @@ Dereferencing "https://example.cborld.com/table1" might then return:
       <h2>JSON-LD to CBOR-LD Algorithm</h2>
 
       <p>
-This algorithm takes a JSON-LD object `jsonldDocument` and `options` as
-input.
+This algorithm takes JSON-LD objects `jsonldDocument` and `options` as well 
+as an integer `varintValue` as input.
       </p>
 
       <ol>
         <li>Let `result` be an empty CBOR-encoded byte array.</li>
         <li>
-Initialize `contextUrls` to the return value of the "Get Context URLs Algorithm"
-passing jsonldDocument as input.
+Set {varintTagValue, varintBytesValue} to the return value of the "Get CBOR Varint Structure
+Algorithm", passing `varintValue` as input.
         </li>
         <li>
-If the "Get Context URLs Algorithm" resulted in an error, set `result` to the
+If the "Get CBOR Varint Structure Algorithm" resulted in an error, set `result` to the
 return value of the "Generate Uncompressed CBOR-LD Algorithm".
         </li>
         <li>
-Otherwise, set `result` to the return value of the "Generate Compressed CBOR-LD
-Algorithm" passing `contextUrls` as `options.contextUrls`.
-        </li>
+Otherwise:
+          <ol>
+            <li>
+Initialize `contextUrls` to an empty map.
+            </li>
+            <li>
+For each entry in the `contextTables` array in the <b>CBOR-LD Varint Registry Entry</b> 
+associated with `varintValue`, dereference the URL and add all entries in the
+`compressionMap` map in the resulting document to `contextUrls`. If "callerProvidedTable" appears
+in `contextTables`, populate `contextUrls` with `options.callerProvidedTable` as well.
+            </li>
+            <li>
+Set `result` to the return value of the "Generate Compressed CBOR-LD
+Algorithm" passing `contextUrls` as `options.contextUrls`, `varintTagValue` as
+`options.varintTagValue`, and `varintBytesValue` as `options.varintBytesValue`.
+            </li>
+            
+          </ol>
+
         <li>Return `result`.</li>
       </ol>
     </section>

--- a/index.html
+++ b/index.html
@@ -452,7 +452,7 @@ The following sections define the exact mechanism by which this can be accomplis
 an arbitrary CBOR-LD consumer to decompress any CBOR-LD payload meeting this specification.
     </p>
     <p>
-To this end, we have registered the range of CBOR tags 1500-1800** to be used for CBOR-LD,
+To this end, we have registered the range of CBOR tags 1536-1791** (0x0600-0x06FF) to be used for CBOR-LD,
 where data that includes tag value is used to lookup what `Compression Table`(s) are needed
 to decompress the CBOR-LD context URLs.
     </p>
@@ -485,10 +485,10 @@ The value of this varint is then used to lookup a <b>CBOR-LD Varint Registry Ent
       <p>
 The <b>CBOR-LD Varint Registry</b> is a global list that provides
 consumers of CBOR-LD payloads the information they need to reconstruct the term codec map
-required for decompression. A  <b>CBOR-LD Varint Registry Entry</b> contains the following:
+required for decompression. A <b>CBOR-LD Varint Registry Entry</b> contains the following:
         <ol>
           <li>
-varint Value: an integer no smaller than 1500.
+varint Value: an integer no smaller than 1536.
           </li>
           <li>
 Use Case: what type of CBOR-LD payload this entry is used for.

--- a/index.html
+++ b/index.html
@@ -793,7 +793,7 @@ If `varintValue` is less than 128:
             Set `varintEncoded` to the byte encoding of `varintValue.
           </li>
           <li>
-  Set 'varintTagValue' to the result of appending `varintEncoded` to the end of the bytes
+  Set `varintTagValue` to the result of appending `varintEncoded` to the end of the bytes
   0xD906, and set `varintBytesValue` to `null`.
           </li>
         </ol>
@@ -802,10 +802,10 @@ If `varintValue` is less than 128:
 Otherwise:
         <ol>
           <li>
-Set 'varintTagValue' to 0xD90680.
+Set `varintTagValue` to 0xD90680.
           </li>
           <li>
-Set 'varintBytesValue' to a CBOR major type 2 bytes object containing a varint representation
+Set `varintBytesValue` to a CBOR major type 2 bytes object containing a varint representation
 of `varintValue`.
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -471,7 +471,8 @@ CBOR tag values, we define the following.
       <p>
 Implementers MUST interpret the last byte of the two-byte CBOR tag value on a CBOR-LD payload
 as the beginning of a varint. If the CBOR tag is `0x0680`, the first item in the CBOR payload
-MUST be a major type 2 byte string containing the rest of the varint. See Algorithm TODO for
+MUST be a major type 2 byte string containing the rest of the varint. See Algorithm <a
+href="#get-cbor-ld-varint-structure-algorithm"></a> for
 more information.
       </p>
       <p>
@@ -521,8 +522,9 @@ Dereferencing one of these URLs MUST result in a JSON object with the following 
         </li>
       </ol>
 `contextCompressionMap` and `contextDecompressionMap` MUST be inverse maps 
-(i.e. `decompression` is identical to `compression`, but with keys and values swapped).
-Similarly. `termCompressionMap` and `termDecompressionMap` MUST be inverse maps.
+(i.e. `contextDecompressionMap` is identical to `contextCompressionMap`, but with keys an
+values swapped). Similarly. `termCompressionMap` and `termDecompressionMap` MUST be inverse
+maps.
       </p>
       <p>
 If multiple `Compression Tables` exist in a single <b>CBOR-LD Varint Registry Entry</b>,
@@ -595,7 +597,7 @@ as an integer `varintValue` as input.
       <ol>
         <li>Let `result` be an empty CBOR-encoded byte array.</li>
         <li>
-Set {varintTagValue, varintBytesValue} to the return value of the "Get CBOR-LD Varint Structure
+Set {`varintTagValue`, `varintBytesValue`} to the return value of the "Get CBOR-LD Varint Structure
 Algorithm", passing `varintValue` as input.
         </li>
         <li>
@@ -684,7 +686,7 @@ The bytes that will make up the rest of the CBOR-LD varint.
 Let `result` be an empty CBOR-encoded byte array.
         </li>
         <li>
-Set the first three bytes of `result` to `options.varintTagValue'.
+Set the first three bytes of `result` to `options.varintTagValue`.
         </li>
         <li>
 If `options.varintBytesValue` is not `null`, set the next bytes of
@@ -781,40 +783,41 @@ error.
         <li>Return `result`.</li>
       </ol>
     </section>
+    <section>
+      <h3>Get CBOR-LD Varint Structure Algorithm</h3>
+  This algorithm takes as input an integer `varintValue`.
+      <ol>
+        <li>
+  If `varintValue` is less than 128:
+          <ol>
+            <li>
+              Set `varintEncoded` to the byte encoding of `varintValue.
+            </li>
+            <li>
+    Set `varintTagValue` to the result of appending `varintEncoded` to the end of the bytes
+    0xD906, and set `varintBytesValue` to `null`.
+            </li>
+          </ol>
+        </li>
+        <li>
+  Otherwise:
+          <ol>
+            <li>
+  Set `varintTagValue` to 0xD90680.
+            </li>
+            <li>
+  Set `varintBytesValue` to a CBOR major type 2 bytes object containing a varint representation
+  of `varintValue`.
+            </li>
+          </ol>
+        </li>
+        <li>
+  Return {varintTagValue, varintBytesValue}.
+        </li>
+      </ol>
+    </section>
   </section>
-  <section>
-    <h3>Get CBOR-LD Varint Structure</h3>
-This algorithm takes as input an integer `varintValue`.
-    <ol>
-      <li>
-If `varintValue` is less than 128:
-        <ol>
-          <li>
-            Set `varintEncoded` to the byte encoding of `varintValue.
-          </li>
-          <li>
-  Set `varintTagValue` to the result of appending `varintEncoded` to the end of the bytes
-  0xD906, and set `varintBytesValue` to `null`.
-          </li>
-        </ol>
-      </li>
-      <li>
-Otherwise:
-        <ol>
-          <li>
-Set `varintTagValue` to 0xD90680.
-          </li>
-          <li>
-Set `varintBytesValue` to a CBOR major type 2 bytes object containing a varint representation
-of `varintValue`.
-          </li>
-        </ol>
-      </li>
-      <li>
-Return {varintTagValue, varintBytesValue}.
-      </li>
-    </ol>
-  </section>
+  
 
   <section class="appendix">
     <h1>Term Codec Registry</h1>

--- a/index.html
+++ b/index.html
@@ -451,7 +451,7 @@ its creation to be able to reconstruct the term codec map.
     </p>
     <p>
 To this end, we have registered the range of CBOR tags 1500-1800** to be used for CBOR-LD,
-where tag values are used to lookup what `Application Context Table`(s) should be used
+where data that includes tag value is used to lookup what `Application Context Table`(s) should be used
 to decompress the CBOR-LD context URLs.
     </p>
     <p>
@@ -460,7 +460,23 @@ to decompress the CBOR-LD context URLs.
 Tag Registry</a>. The exact range is subject to change.
     </p>
     <section>
-      <h2>CBOR-LD </h2>
+      <h2>CBOR-LD Varint Registry</h2>
+      <p>
+A global list of CBOR-LD tags, the <b>CBOR-LD Varint Registry</b> is maintained that provides
+consumers of CBOR-LD payloads the information they need to reconstruct the term codec map
+required for decompression. A  <b>CBOR-LD Varint Registry Entry</b> contains the following:
+        <ol>
+          <li>
+<b>varint Value</b>: an integer in the range 1500-1800.
+          </li>
+          <li>
+<b>Use Case</b>: what type of CBOR-LD payload this entry is used for.
+          </li>
+          <li>
+<b>Context Decompression Needs</b>: what type of CBOR-LD payload this entry is used for.
+          </li>
+        </ol>
+      </p>
     </section>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -460,9 +460,27 @@ to decompress the CBOR-LD context URLs.
 Tag Registry</a>. The exact range is subject to change.
     </p>
     <section>
+      <h2>CBOR-LD Varint</h2>
+      <p>
+To enable unbounded extension on possible use cases for CBOR-LD that require different
+`Application Context Table` material for consumption while working within a fixed number of
+CBOR tag values, we define the following.
+      </p>
+      <p>
+Implementers MUST interpret the last byte of the two-byte CBOR tag value on a CBOR-LD payload
+as the beginning of a varint. If the CBOR tag is `0x0680`, the first item in the CBOR payload
+MUST be a major type 2 byte string containing the rest of the varint. See Algorithm TODO for
+more information.
+      </p>
+      <p>
+The value of this varint is then used to lookup a <b>CBOR-LD Varint Registry Entry</b> in the
+<b>CBOR-LD Varint Registry</b>.
+      </p>
+    </section>
+    <section>
       <h2>CBOR-LD Varint Registry</h2>
       <p>
-A global list of CBOR-LD tags, the <b>CBOR-LD Varint Registry</b> is maintained that provides
+The <b>CBOR-LD Varint Registry</b> is a global list that provides
 consumers of CBOR-LD payloads the information they need to reconstruct the term codec map
 required for decompression. A  <b>CBOR-LD Varint Registry Entry</b> contains the following:
         <ol>

--- a/index.html
+++ b/index.html
@@ -537,7 +537,7 @@ The following is the current CBOR-LD registry:
       <table class="simple">
         <thead>
           <tr>
-            <th>Entry Number</th>
+            <th>Registry Entry Id</th>
             <th>Use Case</th>
             <th>typeTables</th>
             <th>Processing Model</th>
@@ -597,14 +597,14 @@ The following is the current CBOR-LD registry:
 
       <p>
 This algorithm takes JSON-LD objects `jsonldDocument` and `options` as well 
-as an integer `registryValue` as input.
+as an integer `registryEntryId` as input.
       </p>
 
       <ol>
         <li>Let `result` be an empty CBOR-encoded byte array.</li>
         <li>
 Set {`varintTagValue`, `varintBytesValue`} to the return value of the "Get CBOR-LD Varint Structure
-Algorithm", passing `registryValue` as input.
+Algorithm", passing `registryEntryId` as input.
         </li>
         <li>
 If the "Get CBOR-LD Varint Structure Algorithm" resulted in an error, set `result` to the
@@ -614,13 +614,13 @@ return value of the "Generate Uncompressed CBOR-LD Algorithm".
 Otherwise:
           <ol>
             <li>
-Initialize `typeTables`
+Initialize `typeTables` to an empty map
             </li>
             <li>
 For each entry in the `typeTables` array in the <b>CBOR-LD Varint Registry Entry</b> 
-associated with `registryValue`, dereference the URL if necessary and add ${type}: ${table} from
+associated with `registryEntryId`, dereference the URL if necessary and add ${type}: ${table} from
 the resulting document to `typeTables`. If "callerProvidedTable"
-appears in `contextTables`, populate `contextUrls` with `options.callerProvidedTable` as well.
+appears in `contextTables`, populate `typeTables` with `options.callerProvidedTable` as well.
             </li>
             <li>
 Set `result` to the return value of the "Generate Compressed CBOR-LD
@@ -638,7 +638,7 @@ and `varintBytesValue` as `options.varintBytesValue`.
       <h2>Uncompressed CBOR-LD Buffer Algorithm</h2>
 
       <p>
-This algorithm takes a JSON-LD object `jsonldDocument`, integer `registryValue` and 
+This algorithm takes a JSON-LD object `jsonldDocument`, integer `registryEntryId` and 
 `options` as input.
       </p>
 
@@ -665,7 +665,7 @@ This algorithm takes a JSON-LD object `jsonldDocument` and `options` as input.
 The `options` MUST contain:
       </p>
       <dl>
-        <dt>`typeTables`</dt>
+        <dt>`typeTable`</dt>
         <dd>
 A map of JSON-LD types to maps. Each of these maps will map values of the associated
 type to their encoded CBOR-LD values.
@@ -786,13 +786,13 @@ error.
     </section>
     <section>
       <h3>Get CBOR-LD Varint Structure Algorithm</h3>
-This algorithm takes as input an integer `registryValue`.
+This algorithm takes as input an integer `registryEntryId`.
       <ol>
         <li>
-If `registryValue` is less than 128:
+If `registryEntryId` is less than 128:
           <ol>
             <li>
-Set `varintEncoded` to the byte encoding of `registryValue`.
+Set `varintEncoded` to the byte encoding of `registryEntryId`.
             </li>
             <li>
 Set `varintTagValue` to the result of appending `varintEncoded` to the end of the bytes
@@ -804,7 +804,7 @@ Set `varintTagValue` to the result of appending `varintEncoded` to the end of th
 Otherwise:
           <ol>
             <li>
-Set `varintArray` to an array containing the varint representation of `registryValue`.
+Set `varintArray` to an array containing the varint representation of `registryEntryId`.
             </li>
             <li>
 Set `varintTagValue` to `varintArray[0]` appended to the end of the bytes 0xD906.

--- a/index.html
+++ b/index.html
@@ -445,10 +445,11 @@ term.
     <p>
 The first step in decoding a CBOR-LD payload is to recreate the term codec
 map that was used to encode it by processing the contexts in the payload. However,
-as these context URLs are encoded as integers, the consumer of the CBOR-LD
-must know what `Compression Table` (map from JSON-LD terms to integers) was used to
-compress the context URLs during creation to be able to reconstruct the term codec map. 
-The following sections define the exact mechanism by which this can be accomplished, allowing 
+the contexts needed to create the term codec map can have their URLs encoded as integers
+by CBOR-LD. If a CBOR-LD payload contains context URLs compressed in such a way, the
+consumer of the CBOR-LD must know what `Compression Table` (map from JSON-LD terms to integers)
+was used to compress the context URLs during creation to be able to reconstruct the term codec
+map. The following sections define the exact mechanism by which this can be accomplished, allowing 
 an arbitrary CBOR-LD consumer to decompress any CBOR-LD payload meeting this specification.
     </p>
     <p>
@@ -470,7 +471,8 @@ CBOR tag values, we define the following.
       </p>
       <p>
 Implementers MUST interpret the last byte of the two-byte CBOR tag value on a CBOR-LD payload
-as the beginning of a varint. If the CBOR tag is `0x0680`, the first item in the CBOR payload
+as the beginning of a varint. If the CBOR tag is in the range (0x0600-0x067F), the last byte of
+the CBOR tag is a one-byte varint. If the CBOR tag is `0x0680`, the first item in the CBOR payload
 MUST be a major type 2 byte string containing the rest of the varint. See Algorithm <a
 href="#get-cbor-ld-varint-structure-algorithm"></a> for
 more information.

--- a/index.html
+++ b/index.html
@@ -472,8 +472,8 @@ CBOR tag values, we define the following.
       <p>
 Implementers MUST interpret the last byte of the two-byte CBOR tag value on a CBOR-LD payload
 as the beginning of a varint. If the CBOR tag is in the range (0x0600-0x067F), the last byte of
-the CBOR tag is a one-byte varint. If the CBOR tag is `0x0680`, the first item in the CBOR payload
-MUST be a major type 2 byte string containing the rest of the varint. See Algorithm <a
+the CBOR tag is a one-byte varint. If the CBOR tag is `0x0680` or greater, the first item in the
+CBOR payload MUST be a major type 2 byte string containing the rest of the varint. See Algorithm <a
 href="#get-cbor-ld-varint-structure-algorithm"></a> for
 more information.
       </p>
@@ -485,59 +485,114 @@ The value of this varint is then used to lookup a <b>CBOR-LD Varint Registry Ent
     <section>
       <h2>CBOR-LD Varint Registry</h2>
       <p>
-The <b>CBOR-LD Varint Registry</b> is a global list that provides
+The <b>CBOR-LD Registry</b> is a global list that provides
 consumers of CBOR-LD payloads the information they need to reconstruct the term codec map
 required for decompression. A <b>CBOR-LD Varint Registry Entry</b> contains the following:
         <ol>
           <li>
-varint Value: an integer no smaller than 1536.
+Registry Entry Value: a positive integer.
           </li>
           <li>
 Use Case: what type of CBOR-LD payload this entry is used for.
           </li>
           <li>
-`compressionTables`: an array containing what `Compression Tables` must be used for this
+`typeTables`: an array containing what `Type Tables` must be used for this
 type of payload.
+          </li>
+          <li>
+`processingModel`: what processing model is used for this registry entry. A processing model
+specifies how auto-generated CBOR-LD values are created from JSON-LD contexts as well as what
+type encoders are used alongside the `Type Tables` (e.g. how to partially compress an 
+`xsd:dateTime` value that does not appear in `Type Table`). The default processing model,
+which will be defined later in this specification, will be used unless otherwise specified
+in the Registry Entry.
           </li>
         </ol>
       </p>
       <p>
-The `contextTables` associated with a <b>CBOR-LD Varint Registry Entry</b> MUST be an array of
-URLs. The only exception is the string "callerProvidedTable", which may appear in this array,
-denoting that for this use case, a `Compression Table` is required which is not globally
+The `typeTables` associated with a <b>CBOR-LD Varint Registry Entry</b> MUST be an array of
+or JSON objects. The only exception is the string "callerProvidedTable", which may appear in this array,
+denoting that for this use case, a `Type Table` is required which is not globally
 defined.
       </p>
       <p></p>
 Dereferencing one of these URLs MUST result in a JSON object with the following properties:
       <ol>
         <li>
-`contextCompressionMap`: a JSON object that maps URLs to integers.
+`type`: a JSON-LD type.
         </li>
         <li>
-`contextDecompressionMap`: a JSON object that maps integers to URLs.
-        </li>
-        <li>
-`termCompressionMap`: a JSON object that maps JSON-LD terms to integers.
-        </li>
-        <li>
-`termDecompressionMap`: a JSON object that maps integers to JSON-LD terms.
+`table`: a JSON object that maps values of the above type to integers.
         </li>
       </ol>
-`contextCompressionMap` and `contextDecompressionMap` MUST be inverse maps 
-(i.e. `contextDecompressionMap` is identical to `contextCompressionMap`, but with keys an
-values swapped). Similarly. `termCompressionMap` and `termDecompressionMap` MUST be inverse
-maps.
-      </p>
       <p>
-If multiple `Compression Tables` exist in a single <b>CBOR-LD Varint Registry Entry</b>,
-these tables MUST NOT share any integers, URLs, or JSON-LD terms between them.
+If a JSON object is present in the `typeTables` array, it MUST be in the above format.
       </p>
+      <section>
+        <h3>Registry</h3>
+      </section>
+      <p>
+The following is the current CBOR-LD registry:
+      </p>
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>Entry Number</th>
+            <th>Use Case</th>
+            <th>typeTables</th>
+            <th>Processing Model</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+          <td>0</td>
+          <td>Uncompressed CBORLD</td>
+          <td>None</td>
+          <td>DEFAULT</td>
+          </tr>
+          <tr>
+            <td>1</td>
+            <td>Compressed CBORLD, default use case.</td>
+            <td>DEFAULT</td>
+            <td>DEFAULT</td>
+          </tr>
+          <tr>
+            <td>100</td>
+            <td><a href='https://w3c-ccg.github.io/vc-barcodes/'>Verifiable Credential Barcodes Specification Test Vectors</a></td>
+            <td>
+[
+  {
+    type: "context",
+    table:
+    {
+      "https://www.w3.org/ns/credentials/v2": 32768,
+      "https://w3id.org/vc-barcodes/v1": 32769,
+      "https://w3id.org/utopia/v2": 32770
+    }
+  },
+  {
+    type: "https://w3id.org/security#cryptosuiteString",
+    table: 
+    {
+      "ecdsa-rdfc-2019": 1,
+      "ecdsa-sd-2023": 2,
+      "eddsa-rdfc-2022": 3,
+      "ecdsa-xi-2023": 4
+    }
+  }
+]
+            </td>
+            <td>DEFAULT</td>
+          </tr>
+        </tbody>
+      </table>
+
     </section>
 
     <section class="informative">
       <h2>CBOR Varint Registry Example</h2>
       <p>
-As as example, take the following one-entry <b>CBOR-LD Varint Registry</b>:
+As as example, take th one-entry <b>CBOR-LD Varint Registry</b>:
       </p>
       <table class="simple">
         <thead>

--- a/index.html
+++ b/index.html
@@ -606,18 +606,20 @@ return value of the "Generate Uncompressed CBOR-LD Algorithm".
 Otherwise:
           <ol>
             <li>
-Initialize `contextUrls` to an empty map.
+Initialize `contextUrlMap` and `termMap` to empty maps.
             </li>
             <li>
 For each entry in the `contextTables` array in the <b>CBOR-LD Varint Registry Entry</b> 
 associated with `varintValue`, dereference the URL and add all entries in the
-`compressionMap` map in the resulting document to `contextUrls`. If "callerProvidedTable" appears
-in `contextTables`, populate `contextUrls` with `options.callerProvidedTable` as well.
+`contextCompressionMap` map in the resulting document to `contextUrls`. If "callerProvidedTable"
+appears in `contextTables`, populate `contextUrls` with `options.callerProvidedTable` as well.
+Then, add all entries in `termCompressionMap` to `termMap`.
             </li>
             <li>
 Set `result` to the return value of the "Generate Compressed CBOR-LD
-Algorithm" passing `contextUrls` as `options.contextUrls`, `varintTagValue` as
-`options.varintTagValue`, and `varintBytesValue` as `options.varintBytesValue`.
+Algorithm" passing `contextUrls` as `options.contextUrls`, `termMap` as `options.termMap`,
+`varintTagValue` as `options.varintTagValue`, and `varintBytesValue`
+as `options.varintBytesValue`.
             </li>
             
           </ol>
@@ -659,14 +661,21 @@ The `options` MUST contain:
       <dl>
         <dt>`contextUrls`</dt>
         <dd>
-A map of application-specific JSON-LD context URL strings that are mapped to
-their encoded CBOR-LD values. The values MUST be values greater than
-32767 (0x7FFF). Values from 0-32767 (0x0-0x7FFF) are reserved for globally
-recognized JSON-LD Context URL values.
+A map of JSON-LD context URL strings that are mapped to
+their encoded CBOR-LD values.
         </dd>
-        <dt>`applicationTermMap`</dt>
+        <dt>`termMap`</dt>
         <dd>
 A map of JSON-LD terms and their associated CBOR-LD term codecs.
+        </dd>
+        <dt>`varintTagValue`</dt>
+        <dd>
+The CBOR tag value that will be used in the resulting payload.
+        </dd>
+        <dt>`varintBytesValue`</dt>
+        <dd>
+The bytes that will make up the rest of the CBOR-LD varint.
+`options.varintBytesValue` MAY be `null`.  
         </dd>
       </dl>
 
@@ -675,14 +684,16 @@ A map of JSON-LD terms and their associated CBOR-LD term codecs.
 Let `result` be an empty CBOR-encoded byte array.
         </li>
         <li>
-Set the first three bytes of `result` to 0xd90501 (CBOR Tag - 0xd9,
-CBOR-LD - 0x05, Compressed - CBOR-LD compression algorithm version 1 - 0x01,
-Tag 1281)).
+Set the first three bytes of `result` to `options.varintTagValue'.
+        </li>
+        <li>
+If `options.varintBytesValue` is not `null`, set the next bytes of
+`result` to `options.varintBytesValue`.
         </li>
         <li>
 Initialize `termCodecMap` to the result of the <a
-href="#get-term-codec-map-algorithm"></a>, passing `contextUrls` as
-input.
+href="#get-term-codec-map-algorithm"></a>, passing `options.contextUrls` 
+and `options.termMap` as input.
         </li>
         <li>
 Add to `result` by recursively processing every name-value pair in
@@ -708,7 +719,7 @@ function.
       <h2>Get Term Codec Map Algorithm</h2>
 
       <p>
-This algorithm takes a list of URL strings `contextUrls` and returns a CBOR-LD
+This algorithm takes two maps `contextUrls` and `termMap` and returns a CBOR-LD
 term codec map that maps JSON-LD terms to their associated byte values
 and value compression functions.
       </p>
@@ -727,7 +738,7 @@ The first entry should be set to `value` with an undefined value.
                 </li>
                 <li>
 Let `compressor` be a known global compressor function associated with the
-`@type` property, a known local compressor function that was provided to this
+`@type` property, a compressor for this entry provided in `termMap`,
 function, or the generic CBOR compressor function, which returns the bytes
 associated with a typical CBOR compression of the given datatype.
                 </li>

--- a/index.html
+++ b/index.html
@@ -447,7 +447,9 @@ The first step in decoding a CBOR-LD payload is to recreate the term codec
 map that was used to encode it by processing the contexts in the payload. However,
 as these context URLs are encoded as integers, the consumer of the CBOR-LD
 must know what `Application Context Table` (map from URL to integer) was used in
-its creation to be able to reconstruct the term codec map.
+its creation to be able to reconstruct the term codec map. The following sections
+define the exact mechanism by which this can be accomplished, allowing an arbitrary
+CBOR-LD consumer to decompress any CBOR-LD payload meeting this specification.
     </p>
     <p>
 To this end, we have registered the range of CBOR tags 1500-1800** to be used for CBOR-LD,
@@ -491,10 +493,36 @@ required for decompression. A  <b>CBOR-LD Varint Registry Entry</b> contains the
 <b>Use Case</b>: what type of CBOR-LD payload this entry is used for.
           </li>
           <li>
-<b>Context Decompression Needs</b>: what type of CBOR-LD payload this entry is used for.
+<b>Context Tables</b>: what type of CBOR-LD payload this entry is used for.
           </li>
         </ol>
       </p>
+      <p>
+The `Context Tables` associated with a <b>CBOR-LD Varint Registry Entry</b> MUST be an array of
+URLs. The only exception is the string "callerProvidedTable", which may appear in this array,
+denoting that for this use case, an `Application Context Table` is required which is not globally
+defined.
+
+Dereferencing one of these URLs MUST result in a JSON object with the following properties:
+      </p>
+      <ol>
+        `compression`: a JSON object that maps URLs to integers.
+        `decompression`: a JSON object that maps integers to URLs.
+      </ol>
+`compression` and `decompression` MUST be inverse maps (i.e. `decompression` is identical to
+`compression`, but with keys and values swapped).
+      </p>
+      <p>
+      </p>
+    </section>
+    <section>
+      <h2>CBOR-LD Varint Registry Entry Tables</h2>
+      <p>
+Aside from the varint value that identifies a <b>CBOR-LD Varint Registry Entry</b> and its use
+case, an entry contains specification of what `Application Context Table`(s) are needed for
+decompression.
+      </p>
+
     </section>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -487,42 +487,83 @@ consumers of CBOR-LD payloads the information they need to reconstruct the term 
 required for decompression. A  <b>CBOR-LD Varint Registry Entry</b> contains the following:
         <ol>
           <li>
-<b>varint Value</b>: an integer in the range 1500-1800.
+varint Value: an integer in the range 1500-1800.
           </li>
           <li>
-<b>Use Case</b>: what type of CBOR-LD payload this entry is used for.
+Use Case: what type of CBOR-LD payload this entry is used for.
           </li>
           <li>
-<b>Context Tables</b>: what type of CBOR-LD payload this entry is used for.
+`contextTables`: an array containing what `Application Context Tables` must be used for this
+type of payload..
           </li>
         </ol>
       </p>
       <p>
-The `Context Tables` associated with a <b>CBOR-LD Varint Registry Entry</b> MUST be an array of
+The `contextTables` associated with a <b>CBOR-LD Varint Registry Entry</b> MUST be an array of
 URLs. The only exception is the string "callerProvidedTable", which may appear in this array,
 denoting that for this use case, an `Application Context Table` is required which is not globally
 defined.
-
-Dereferencing one of these URLs MUST result in a JSON object with the following properties:
       </p>
+      <p></p>
+Dereferencing one of these URLs MUST result in a JSON object with the following properties:
       <ol>
-        `compression`: a JSON object that maps URLs to integers.
-        `decompression`: a JSON object that maps integers to URLs.
+        <li>
+`compressionMap`: a JSON object that maps URLs to integers.
+        </li>
+        <li>
+`decompressionMap`: a JSON object that maps integers to URLs.
+        </li>
       </ol>
-`compression` and `decompression` MUST be inverse maps (i.e. `decompression` is identical to
+`compressionMap` and `decompressionMap` MUST be inverse maps (i.e. `decompression` is identical to
 `compression`, but with keys and values swapped).
       </p>
       <p>
+If multiple `Application Context Tables` exist in a single <b>CBOR-LD Varint Registry Entry</b>,
+these tables MUST NOT share any integer or URL values between them.
       </p>
     </section>
-    <section>
-      <h2>CBOR-LD Varint Registry Entry Tables</h2>
-      <p>
-Aside from the varint value that identifies a <b>CBOR-LD Varint Registry Entry</b> and its use
-case, an entry contains specification of what `Application Context Table`(s) are needed for
-decompression.
-      </p>
 
+    <section class="informative">
+      <h2>CBOR Varint Registry Example</h2>
+TODO: ok to have informative subsection of normative section? If not, ok to have examples in
+normative section?
+      <p>
+As as example, take the following one-entry <b>CBOR-LD Varint Registry</b>:
+      </p>
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>Value</th>
+            <th>Use Case</th>
+            <th>contextTables</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+          <td>100</td>
+          <td>Specification Example</td>
+          <td>["https://example.cborld.com/table1", "https://example.cborld.com/table2"]</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+Dereferencing "https://example.cborld.com/table1" might then return:
+      </p>
+      <pre class="example nohighlight"
+             title="Example results derefencing contextTables entries">
+{
+  "compressionMap":
+    {
+      "https://w3id.org/ns/credentials/v2": 32900,
+      "https://example.cborld.com/context1": 32901
+    },
+  "decompressionMap":
+    {
+      32900: "https://w3id.org/ns/credentials/v2",
+      32901: "https://example.cborld.com/context1"
+    }
+}
+        </pre>
     </section>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -595,11 +595,11 @@ as an integer `varintValue` as input.
       <ol>
         <li>Let `result` be an empty CBOR-encoded byte array.</li>
         <li>
-Set {varintTagValue, varintBytesValue} to the return value of the "Get CBOR Varint Structure
+Set {varintTagValue, varintBytesValue} to the return value of the "Get CBOR-LD Varint Structure
 Algorithm", passing `varintValue` as input.
         </li>
         <li>
-If the "Get CBOR Varint Structure Algorithm" resulted in an error, set `result` to the
+If the "Get CBOR-LD Varint Structure Algorithm" resulted in an error, set `result` to the
 return value of the "Generate Uncompressed CBOR-LD Algorithm".
         </li>
         <li>
@@ -781,6 +781,39 @@ error.
         <li>Return `result`.</li>
       </ol>
     </section>
+  </section>
+  <section>
+    <h3>Get CBOR-LD Varint Structure</h3>
+This algorithm takes as input an integer `varintValue`.
+    <ol>
+      <li>
+If `varintValue` is less than 128:
+        <ol>
+          <li>
+            Set `varintEncoded` to the byte encoding of `varintValue.
+          </li>
+          <li>
+  Set 'varintTagValue' to the result of appending `varintEncoded` to the end of the bytes
+  0xD906, and set `varintBytesValue` to `null`.
+          </li>
+        </ol>
+      </li>
+      <li>
+Otherwise:
+        <ol>
+          <li>
+Set 'varintTagValue' to 0xD90680.
+          </li>
+          <li>
+Set 'varintBytesValue' to a CBOR major type 2 bytes object containing a varint representation
+of `varintValue`.
+          </li>
+        </ol>
+      </li>
+      <li>
+Return {varintTagValue, varintBytesValue}.
+      </li>
+    </ol>
   </section>
 
   <section class="appendix">

--- a/index.html
+++ b/index.html
@@ -446,14 +446,14 @@ term.
 The first step in decoding a CBOR-LD payload is to recreate the term codec
 map that was used to encode it by processing the contexts in the payload. However,
 as these context URLs are encoded as integers, the consumer of the CBOR-LD
-must know what `Application Context Table` (map from context URLs to integers) was used in
-its creation to be able to reconstruct the term codec map. The following sections
-define the exact mechanism by which this can be accomplished, allowing an arbitrary
-CBOR-LD consumer to decompress any CBOR-LD payload meeting this specification.
+must know what `Compression Table` (map from JSON-LD terms to integers) was used to
+compress the context URLs during creation to be able to reconstruct the term codec map. 
+The following sections define the exact mechanism by which this can be accomplished, allowing 
+an arbitrary CBOR-LD consumer to decompress any CBOR-LD payload meeting this specification.
     </p>
     <p>
 To this end, we have registered the range of CBOR tags 1500-1800** to be used for CBOR-LD,
-where data that includes tag value is used to lookup what `Application Context Table`(s) are needed
+where data that includes tag value is used to lookup what `Compression Table`(s) are needed
 to decompress the CBOR-LD context URLs.
     </p>
     <p>
@@ -465,7 +465,7 @@ Tag Registry</a>. The exact range is subject to change.
       <h2>CBOR-LD Varint</h2>
       <p>
 To enable unbounded extension on possible use cases for CBOR-LD that require different
-`Application Context Table` material for consumption while working within a fixed number of
+`Compression Table` material for consumption while working within a fixed number of
 CBOR tag values, we define the following.
       </p>
       <p>
@@ -487,46 +487,51 @@ consumers of CBOR-LD payloads the information they need to reconstruct the term 
 required for decompression. A  <b>CBOR-LD Varint Registry Entry</b> contains the following:
         <ol>
           <li>
-varint Value: an integer in the range 1500-1800.
+varint Value: an integer no smaller than 1500.
           </li>
           <li>
 Use Case: what type of CBOR-LD payload this entry is used for.
           </li>
           <li>
-`contextTables`: an array containing what `Application Context Tables` must be used for this
-type of payload..
+`compressionTables`: an array containing what `Compression Tables` must be used for this
+type of payload.
           </li>
         </ol>
       </p>
       <p>
 The `contextTables` associated with a <b>CBOR-LD Varint Registry Entry</b> MUST be an array of
 URLs. The only exception is the string "callerProvidedTable", which may appear in this array,
-denoting that for this use case, an `Application Context Table` is required which is not globally
+denoting that for this use case, a `Compression Table` is required which is not globally
 defined.
       </p>
       <p></p>
 Dereferencing one of these URLs MUST result in a JSON object with the following properties:
       <ol>
         <li>
-`compressionMap`: a JSON object that maps URLs to integers.
+`contextCompressionMap`: a JSON object that maps URLs to integers.
         </li>
         <li>
-`decompressionMap`: a JSON object that maps integers to URLs.
+`contextDecompressionMap`: a JSON object that maps integers to URLs.
+        </li>
+        <li>
+`termCompressionMap`: a JSON object that maps JSON-LD terms to integers.
+        </li>
+        <li>
+`termDecompressionMap`: a JSON object that maps integers to JSON-LD terms.
         </li>
       </ol>
-`compressionMap` and `decompressionMap` MUST be inverse maps (i.e. `decompression` is identical to
-`compression`, but with keys and values swapped).
+`contextCompressionMap` and `contextDecompressionMap` MUST be inverse maps 
+(i.e. `decompression` is identical to `compression`, but with keys and values swapped).
+Similarly. `termCompressionMap` and `termDecompressionMap` MUST be inverse maps.
       </p>
       <p>
-If multiple `Application Context Tables` exist in a single <b>CBOR-LD Varint Registry Entry</b>,
-these tables MUST NOT share any integer or URL values between them.
+If multiple `Compression Tables` exist in a single <b>CBOR-LD Varint Registry Entry</b>,
+these tables MUST NOT share any integers, URLs, or JSON-LD terms between them.
       </p>
     </section>
 
     <section class="informative">
       <h2>CBOR Varint Registry Example</h2>
-TODO: ok to have informative subsection of normative section? If not, ok to have examples in
-normative section?
       <p>
 As as example, take the following one-entry <b>CBOR-LD Varint Registry</b>:
       </p>
@@ -552,15 +557,25 @@ Dereferencing "https://example.cborld.com/table1" might then return:
       <pre class="example nohighlight"
              title="Example results derefencing contextTables entries">
 {
-  "compressionMap":
+  "contextCompressionMap":
     {
       "https://w3id.org/ns/credentials/v2": 32900,
       "https://example.cborld.com/context1": 32901
     },
-  "decompressionMap":
+  "contextDecompressionMap":
     {
       32900: "https://w3id.org/ns/credentials/v2",
       32901: "https://example.cborld.com/context1"
+    },
+  "termCompressionMap":
+    {
+      "ecdsa-xi-2023": 35000,
+      "ecdsa-rdfc-2019": 35001
+    },
+  "termDecompressionMap":
+    {
+      35000: "ecdsa-xi-2023",
+      35001: "ecdsa-rdfc-2019"
     }
 }
         </pre>
@@ -642,7 +657,7 @@ This algorithm takes a JSON-LD object `jsonldDocument` and `options` as input.
 The `options` MUST contain:
       </p>
       <dl>
-        <dt>`applicationContextMap`</dt>
+        <dt>`contextUrls`</dt>
         <dd>
 A map of application-specific JSON-LD context URL strings that are mapped to
 their encoded CBOR-LD values. The values MUST be values greater than


### PR DESCRIPTION
- defines CBOR tag/varint system needed for retrieving data needed for decoding
- defines registry system for registering tables associated with a tag/varint
- adds new algorithms to support the above
- updates existing algorithms to support the above


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wes-smith/cbor-ld-spec/pull/28.html" title="Last updated on Jul 15, 2024, 1:36 PM UTC (c79af99)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/cbor-ld-spec/28/4edf4bc...wes-smith:c79af99.html" title="Last updated on Jul 15, 2024, 1:36 PM UTC (c79af99)">Diff</a>