### PR TITLE
Update 10002 context subtable and name.

### DIFF
--- a/index.html
+++ b/index.html
@@ -633,7 +633,7 @@ The following is the current CBOR-LD registry:
           </tr>
           <tr>
             <td>10002</td>
-            <td>Provisional First Responder SAP Credentials</td>
+            <td>Provisional First Responder Credentials</td>
             <td>
 [
   {

--- a/index.html
+++ b/index.html
@@ -643,6 +643,8 @@ The following is the current CBOR-LD registry:
       "https://www.w3.org/ns/credentials/v2": 1,
       "https://w3id.org/vc-barcodes/v1": 2,
       "https://w3id.org/first-responder/sap/v1rc1": 3,
+      "https://w3id.org/first-responder/v1", 4,
+      "https://w3id.org/first-responder/v2rc1", 5
     }
   },
   {


### PR DESCRIPTION
#### _Resolves - 10002 update_

---

### What kind of change does this PR introduce?

- Context subtable update to 10002
- Update 10002 name

<br/>

### What is the current behavior?

- 10002 has 3 contexts
- 10002's name `Provisional First Responder SAP Credentials`

<br/>

### What is the new behavior?

- Adding 2 more context to 10002 context subtable
- Remove `SAP` from 10002 name

<br/>

### Does this PR introduce a breaking change?

- No

<br/>

### How has this been tested?

- Locally

<br/>

### Screenshots:

- n/a


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jameseaster/cbor-ld-spec/pull/40.html" title="Last updated on Apr 1, 2025, 4:25 PM UTC (69cb112)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/cbor-ld-spec/40/07b4609...jameseaster:69cb112.html" title="Last updated on Apr 1, 2025, 4:25 PM UTC (69cb112)">Diff</a>