### PR TITLE
Format type tables.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2

--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
   .comment {
     color: #999;
   }
-  table, thead, tr, td {
+  table, thead, tr, td, th {
     padding: 5px;
     border-width: 1px;
     border-spacing: 0px;

--- a/index.html
+++ b/index.html
@@ -573,6 +573,7 @@ The following is the current CBOR-LD registry:
             <td>100</td>
             <td><a href='https://w3c-ccg.github.io/vc-barcodes/'>Verifiable Credential Barcodes Specification Test Vectors</a></td>
             <td>
+              <pre>
 [
   {
     type: "context",
@@ -594,6 +595,7 @@ The following is the current CBOR-LD registry:
     }
   }
 ]
+              </pre>
             </td>
             <td>DEFAULT</td>
             <td>Yes</td>
@@ -602,6 +604,7 @@ The following is the current CBOR-LD registry:
             <td>10001</td>
             <td>Provisional California DMV Credentials</td>
             <td>
+              <pre>
 [
   {
     type: "context",
@@ -630,6 +633,7 @@ The following is the current CBOR-LD registry:
     }
   }
 ]
+              </pre>
             </td>
             <td>DEFAULT</td>
             <td>Yes</td>
@@ -638,6 +642,7 @@ The following is the current CBOR-LD registry:
             <td>10002</td>
             <td>Provisional First Responder Credentials</td>
             <td>
+              <pre>
 [
   {
     type: "context",
@@ -667,6 +672,7 @@ The following is the current CBOR-LD registry:
     }
   }
 ]
+              </pre>
             </td>
             <td>DEFAULT</td>
             <td>Yes</td>

--- a/index.html
+++ b/index.html
@@ -506,6 +506,7 @@ The value of this varint is then used to lookup a <b>CBOR-LD Varint Registry Ent
 The <b>CBOR-LD Registry</b> is a global list that provides
 consumers of CBOR-LD payloads the information they need to reconstruct the term codec map
 required for decompression. A <b>CBOR-LD Varint Registry Entry</b> contains the following:
+      </p>
         <ol>
           <li>
 Registry Entry ID: a positive integer.
@@ -530,15 +531,15 @@ Provisional: a yes/no flag indicating whether the entry is provisional. Provisio
 may change or be removed.
           </li>
         </ol>
-      </p>
       <p>
 The `typeTables` associated with a <b>CBOR-LD Varint Registry Entry</b> MUST be an array of
 or JSON objects. The only exception is the string "callerProvidedTable", which may appear in this array,
 denoting that for this use case, a `Type Table` is required which is not globally
 defined.
       </p>
-      <p></p>
+      <p>
 Dereferencing one of these URLs MUST result in a JSON object with the following properties:
+      </p>
       <ol>
         <li>
 `type`: a JSON-LD type.
@@ -2396,6 +2397,7 @@ Return `result`.
         </ol>
       </section>
     </section>
+  </section>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -464,7 +464,7 @@ the contexts needed to create the term codec map can have their URLs encoded as 
 by CBOR-LD. If a CBOR-LD payload contains context URLs compressed in such a way, the
 consumer of the CBOR-LD needs to know what compression tables (maps from JSON-LD terms to integers)
 were used to compress the context URLs during creation to be able to reconstruct the term codec
-map. The following sections define the exact mechanism by which this can be accomplished, allowing 
+map. The following sections define the exact mechanism by which this can be accomplished, allowing
 an arbitrary CBOR-LD consumer to decompress any CBOR-LD payload that conforms to this specification.
     </p>
     <p>
@@ -520,7 +520,7 @@ type of payload.
           <li>
 `processingModel`: what processing model is used for this registry entry. A processing model
 specifies how auto-generated CBOR-LD values are created from JSON-LD contexts as well as what
-type encoders are used alongside the `Type Tables` (e.g. how to partially compress an 
+type encoders are used alongside the `Type Tables` (e.g. how to partially compress an
 `xsd:dateTime` value that does not appear in `Type Table`). The default processing model,
 which will be defined later in this specification, will be used unless otherwise specified
 in the Registry Entry.
@@ -601,7 +601,7 @@ The following is the current CBOR-LD registry:
   },
   {
     type: "https://w3id.org/security#cryptosuiteString",
-    table: 
+    table:
     {
       "ecdsa-rdfc-2019": 1,
       "ecdsa-sd-2023": 2,
@@ -633,14 +633,14 @@ The following is the current CBOR-LD registry:
   },
   {
     type: "https://w3id.org/security#cryptosuiteString",
-    table: 
+    table:
     {
       "ecdsa-rdfc-2019": 1
     }
   },
   {
     type: "url",
-    table: 
+    table:
     {
       "did:key:zDnaeW9VZZs7NH1ykvS5EMFmdodu2wj4dPcrV3DzTAadrXJee": 1,
       "did:key:zDnaeW9VZZs7NH1ykvS5EMFmdodu2wj4dPcrV3DzTAadrXJee#zDnaeW9VZZs7NH1ykvS5EMFmdodu2wj4dPcrV3DzTAadrXJee": 2,
@@ -672,14 +672,14 @@ The following is the current CBOR-LD registry:
   },
   {
     type: "https://w3id.org/security#cryptosuiteString",
-    table: 
+    table:
     {
       "ecdsa-rdfc-2019": 1
     }
   },
   {
     type: "url",
-    table: 
+    table:
     {
       "did:key:zDnaeW9VZZs7NH1ykvS5EMFmdodu2wj4dPcrV3DzTAadrXJee": 1,
       "did:key:zDnaeW9VZZs7NH1ykvS5EMFmdodu2wj4dPcrV3DzTAadrXJee#zDnaeW9VZZs7NH1ykvS5EMFmdodu2wj4dPcrV3DzTAadrXJee": 2,
@@ -808,7 +808,7 @@ Set `state` to the result of passing `state` to
           </li>
           <li>
 Set `state.initialActiveContext` to the result of passing empty maps `termMap` and
-`previousActiveContext` to <a href="#initialize-active-context-algorithm"></a>.            
+`previousActiveContext` to <a href="#initialize-active-context-algorithm"></a>.
           </li>
           <li>
 Set `state.typesEncodedAsBytes` to an empty set.
@@ -875,7 +875,7 @@ If `state.strategy` is set to "compression":
               <li>
 Set `contextConversionResult` to the result of
 <a href="#convert-contexts-for-compression-algorithm"></a>, passing
-`state`, `activeContext`, `input`, and `output`.                 
+`state`, `activeContext`, `input`, and `output`.
               </li>
               <li>
 Set `activeContext` to `contextConversionResult.activeContext`, `output`
@@ -885,7 +885,7 @@ to `contextConversionResult.output`, and `state` to `contextConversionResult.sta
           </li>
           <li>
 Otherwise, set `activeContext` to
-`result.activeContext` and `state` to `result.state` of `result` resulting from 
+`result.activeContext` and `state` to `result.state` of `result` resulting from
 <a href="#convert-contexts-for-decompression-algorithm"></a>, passing `state`,
 `activeContext`, `input`, and `output`.
           </li>
@@ -912,7 +912,7 @@ If `state.strategy` is set to "compression", set `state` to `result.state` and
           </li>
           <li>
 Otherwise, set `state` to `result.state`, `output` to `result.output`,
-and `termEntries` to `result.termEntries` for `result` resulting from 
+and `termEntries` to `result.termEntries` for `result` resulting from
 <a href="#get-input-entries-for-decompression-algorithm"></a>,
 passing `state`, `input`, output, and `activeContext`.
           </li>
@@ -1021,7 +1021,7 @@ Set `result` to be an empty map. Set `result`.`state` to `state` and `result`.`o
 Set `output` to an empty map.
           </li>
           <li>
-Set `result` to the result of <a href="#general-conversion-algorithm"></a>, passing `state`, 
+Set `result` to the result of <a href="#general-conversion-algorithm"></a>, passing `state`,
 `activeContext`, `value` as `input`, and `output`.
           </li>
           <li>
@@ -1225,7 +1225,7 @@ convert CBOR-LD to JSON-LD.
         <section>
           <h4>Convert Contexts for Decompression Algorithm</h4>
           <p>
-This algorithm takes maps `state`, `activeContext`, `input`, and `output`, and returns a map 
+This algorithm takes maps `state`, `activeContext`, `input`, and `output`, and returns a map
 `result` containing maps `output`, `state`, and `activeContext`.
           </p>
           <ol>
@@ -1236,7 +1236,7 @@ Set `decoderData` to the result of <a href="#create-context-decoder"></a>, passi
 Set `contextTermId` to the value of "@context" in `state`.`keywordsMap`.
             </li>
             <li>
-If `contextTermId` has an entry in `input`, set the value of 
+If `contextTermId` has an entry in `input`, set the value of
 "@context" in `output` to the result of <a href="#decode-context"></a>, passing `decoderData` and
 the value of `contextTermId` in `input` as `value`.
             </li>
@@ -1340,7 +1340,7 @@ an entry, throw an error ERR_UNKNOWN_CBORLD_TERM_ID.
                   </ol>
                 </li>
                 <li>
-Set `definition` to the value of `term` in `activeContext`.`termMap`.          
+Set `definition` to the value of `term` in `activeContext`.`termMap`.
                 </li>
                 <li>
 Set `entryTerm` to be a new map.
@@ -1413,7 +1413,7 @@ an entry, throw an error ERR_UNKNOWN_CBORLD_TERM_ID.
                   </ol>
                 </li>
                 <li>
-Set `definition` to the value of `term` in `activeContext`.`termMap`.          
+Set `definition` to the value of `term` in `activeContext`.`termMap`.
                 </li>
                 <li>
 Set `termInfo` to be a new map.
@@ -1506,7 +1506,7 @@ returns a map `result` containing maps `state` and `activeContext`.
             <ol>
               <li>
 Set `termMapUpdateResult` to the result of passing `state`, `activeContext.termMap` as
-`activeTermMap`, and the value of '@context' in `input` as `contexts` to 
+`activeTermMap`, and the value of '@context' in `input` as `contexts` to
 <a href="#update-term-map-algorithm"></a>.
               </li>
               <li>
@@ -1524,7 +1524,7 @@ Set `result` to be a new map, and set `result.activeContext` to `newActiveContex
 `result.state` to `state`.
               </li>
               <li>
-Return `result`. 
+Return `result`.
               </li>
             </ol>
         </section>
@@ -1545,7 +1545,7 @@ Set `termDef` to the value of `term` in `activeContext.termMap`. Set `contexts` 
             </li>
             <li>
 Set `termMapUpdateResult` to the result of passing `state`, `revertedTermMap` as
-`activeTermMap`, `true` as `propertyScope`, and `contexts` to 
+`activeTermMap`, `true` as `propertyScope`, and `contexts` to
 <a href="#update-term-map-algorithm"></a>.
             </li>
             <li>
@@ -1563,7 +1563,7 @@ Set `result` to be a new map, and set `result.activeContext` to `newActiveContex
 `result.state` to `state`.
             </li>
             <li>
-Return `result`. 
+Return `result`.
             </li>
           </ol>
         </section>
@@ -1611,7 +1611,7 @@ Set `result` to be a new map, and set `result.activeContext` to `newActiveContex
 `result.state` to `state`.
               </li>
               <li>
-Return `result`. 
+Return `result`.
               </li>
           </ol>
         </section>
@@ -1652,13 +1652,13 @@ Set `newTermMap` to be an empty map. For [`key`, `value`] in `entry`.`termMap`:
                   <ol>
                     <li>
 Shallow copy the contents of `value` into a new map `newValue` and add `propagate`
-to `newValue`. 
+to `newValue`.
                     </li>
                     <li>
 Set the value of `key` in `newTermMap` to `newValue`.
                     </li>
                   </ol>
-                </li> 
+                </li>
                 <li>
 For [`term`, `activeDef`] in `activeTermMap`:
                   <ol>
@@ -1691,7 +1691,7 @@ a map containing all values from `activeDef`.
                 </li>
                 <li>
 Set the value of `activeTermMap` to the value of `newTermMap`.
-                </li>   
+                </li>
               </ol>
             </li>
             <li>
@@ -1760,7 +1760,7 @@ Return `newTermMap`.
             </li>
           </ol>
         </section>
-    </section>    
+    </section>
 
     <section>
       <h2>Context Loading</h2>
@@ -2301,8 +2301,8 @@ This algorithm takes a map `decoderData`, and returns a value.
           </p>
           <ol>
             <li>
-Return `decoderData`.`decoded`.  
-            </li>          
+Return `decoderData`.`decoded`.
+            </li>
           </ol>
         </section>
       </section>
@@ -2363,7 +2363,7 @@ ERR_NON_CBOR_LD_TAG error.
           </li>
           <li>
 Otherwise, if the CBOR tag on `cborldBytes` is in the range `0x0600`-`0x067F`, set `registryEntryId` to
-the value of the last byte of the CBOR tag and set `suffix` to the portion of `cborldBytes` after the tag.          
+the value of the last byte of the CBOR tag and set `suffix` to the portion of `cborldBytes` after the tag.
           </li>
           <li>
 Otherwise:
@@ -2382,7 +2382,7 @@ byte of the CBOR tag and the rest of the varint is the first element in the two 
 value of the second element in the array.
               </li>
             </ol>
-            
+
           </li>
           <li>
 Set `result` to be an empty map.

--- a/index.html
+++ b/index.html
@@ -544,7 +544,8 @@ If a JSON object is present in the `typeTables` array, it MUST be in the above f
       <p>
 The following is the current CBOR-LD registry:
       </p>
-      <table class="simple">
+
+      <table>
         <thead>
           <tr>
             <th>Registry Entry Id</th>

--- a/index.html
+++ b/index.html
@@ -562,29 +562,31 @@ The following is the current CBOR-LD registry:
           <tr>
             <th>Registry Entry Id</th>
             <th>Use Case</th>
-            <th>typeTables</th>
             <th>Processing Model</th>
             <th>Provisional</th>
+            <th>typeTables</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-          <td>0</td>
-          <td>Uncompressed CBORLD</td>
-          <td>None</td>
-          <td>DEFAULT</td>
-          <td>No</td>
+            <td>0</td>
+            <td>Uncompressed CBORLD</td>
+            <td>DEFAULT</td>
+            <td>No</td>
+            <td>None</td>
           </tr>
           <tr>
             <td>1</td>
             <td>Compressed CBORLD, default use case.</td>
             <td>DEFAULT</td>
-            <td>DEFAULT</td>
             <td>No</td>
+            <td>DEFAULT</td>
           </tr>
           <tr>
             <td>100</td>
             <td><a href='https://w3c-ccg.github.io/vc-barcodes/'>Verifiable Credential Barcodes Specification Test Vectors</a></td>
+            <td>DEFAULT</td>
+            <td>Yes</td>
             <td>
               <pre>
 [
@@ -610,12 +612,12 @@ The following is the current CBOR-LD registry:
 ]
               </pre>
             </td>
-            <td>DEFAULT</td>
-            <td>Yes</td>
           </tr>
           <tr>
             <td>10001</td>
             <td>Provisional California DMV Credentials</td>
+            <td>DEFAULT</td>
+            <td>Yes</td>
             <td>
               <pre>
 [
@@ -648,12 +650,12 @@ The following is the current CBOR-LD registry:
 ]
               </pre>
             </td>
-            <td>DEFAULT</td>
-            <td>Yes</td>
           </tr>
           <tr>
             <td>10002</td>
             <td>Provisional First Responder Credentials</td>
+            <td>DEFAULT</td>
+            <td>Yes</td>
             <td>
               <pre>
 [
@@ -687,8 +689,6 @@ The following is the current CBOR-LD registry:
 ]
               </pre>
             </td>
-            <td>DEFAULT</td>
-            <td>Yes</td>
           </tr>
         </tbody>
       </table>

--- a/index.html
+++ b/index.html
@@ -105,10 +105,22 @@
   };
 </script>
 <style>
-  .hl-bold { font-weight: bold; color: #0a3; }
-  .comment { color: #999; }
-  table, thead, tr, td { padding: 5px; border-width: 1px; border-spacing: 0px; border-style: solid; border-collapse: collapse; }
-  table.example {width: 100%;}
+  .hl-bold {
+    font-weight: bold; color: #0a3;
+  }
+  .comment {
+    color: #999;
+  }
+  table, thead, tr, td {
+    padding: 5px;
+    border-width: 1px;
+    border-spacing: 0px;
+    border-style: solid;
+    border-collapse: collapse;
+  }
+  table.example {
+    width: 100%;
+  }
   .example > pre.context:before {
     content: "Context";
     float: right;


### PR DESCRIPTION
- Add `<pre>` formatting to `typeTable` data for easier readability.
- This causes `typeTable` data cells to be wide, they were moved to the end so other columns easier to see.
- Adding inner-cell scrolling was too difficult.  Leaving as is for now.  I suspect the table will need reformatting, be moved to another doc, and/or the `typeTable` data structures could be moved out into sections below the table itself, and have better scrolling.  Scrolling the who table with an `overflow-x: scroll` wrapper is not hard, but looked odd.
- Got a bit carried away and fixed some markup, formatting, and extra whitespace.
- Various parts of the markup could have indention synced properly for the section levels.  Left as is for now since that's time consuming.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/cbor-ld-spec/pull/42.html" title="Last updated on Apr 2, 2025, 1:45 AM UTC (5f454fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/cbor-ld-spec/42/29d8a3d...5f454fd.html" title="Last updated on Apr 2, 2025, 1:45 AM UTC (5f454fd)">Diff</a>