### PR TITLE
Remove inline registry table, point to external repository/document.

### DIFF
--- a/index.html
+++ b/index.html
@@ -552,7 +552,7 @@ If a JSON object is present in the `typeTables` array, it MUST be in the above f
 The current CBOR-LD Registry can be found <a href="https://json-ld.github.io/cborld-registry/">here</a>.
       </p>
       <p>
-To register an entry, follow the instructions in <a href="https://github.com/json-ld/cborld-registry">the README</a>.
+To register an entry, follow the instructions in <a href="https://github.com/json-ld/cborld-registry">the README</a>. The registry is owned by the W3C JSON-LD Community Group.
       </p>
 
     </section>


### PR DESCRIPTION
This PR replaces the inline expression of the CBOR-LD Registry with links to a second repository and document for readability and ease of management.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wes-smith/cbor-ld-spec/pull/53.html" title="Last updated on Feb 11, 2026, 5:47 PM UTC (100a988)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cbor-ld/53/e37513c...wes-smith:100a988.html" title="Last updated on Feb 11, 2026, 5:47 PM UTC (100a988)">Diff</a>