### PR TITLE
Remove tag registration issue, cleanup wording around CBOR tag.

### DIFF
--- a/index.html
+++ b/index.html
@@ -468,14 +468,10 @@ map. The following sections define the exact mechanism by which this can be acco
 an arbitrary CBOR-LD consumer to decompress any CBOR-LD payload that conforms to this specification.
     </p>
     <p>
-To this end, we have registered the CBOR tag `0xCB1D` (tag value 51997) to be used for CBOR-LD.
-The data that follows this tag value is used to look up what compression table(s) are needed
-to decompress the CBOR-LD context URLs.
-    </p>
-    <p class="issue">
-This exact tag value has not yet been officially registered with
-<a href="https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml">the IANA CBOR
-Tag Registry</a>. The exact value is subject to change.
+To this end, the CBOR tag `0xCB1D` (tag value 51997) is registered at 
+<a href="https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml">the IANA CBOR tag registry</a> to be used for CBOR-LD.
+The data that immediately follows this tag value identifies what use-case-specific registry entry (if any) was used to create
+the compressed payload.
     </p>
     <section>
       <h2>CBOR-LD Registry Entry Id</h2>


### PR DESCRIPTION
This PR removes an outdated issue from the specification text saying the CBOR tag 51997 for CBOR-LD has not been registered at IANA yet - this is no longer true. The PR also contains small wording improvements and cleanup regarding CBOR-LD tags.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wes-smith/cbor-ld-spec/pull/54.html" title="Last updated on Jan 13, 2026, 6:04 PM UTC (4749e5f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/cbor-ld-spec/54/e37513c...wes-smith:4749e5f.html" title="Last updated on Jan 13, 2026, 6:04 PM UTC (4749e5f)">Diff</a>