### PR TITLE
Update top-level encoding/decoding algorithms to support uncompressed use cases.

### DIFF
--- a/index.html
+++ b/index.html
@@ -561,7 +561,7 @@ compression feature and are not used in conversions between CBOR-LD and JSON-LD 
 the CBOR-LD payload does not use semantic compression.
       <h2>Encoding and Decoding</h2>
       <section>
-        <h3>JSON-LD to CBOR-LD Algorithm</h3>
+        <h3>JSON-LD to CBOR-LD Encoding Algorithm</h3>
         <p>
 This algorithm takes a map `typeTable`, an integer `registryEntryId`, and a JSON-LD
 document `jsonldDocument` as inputs, and returns a hexadecimal string `cborldBytes`.
@@ -611,7 +611,7 @@ Return `cborldBytes`.
         </ol>
       </section>
       <section>
-        <h3>CBOR-LD to JSON-LD Decompression Algorithm</h3>
+        <h3>CBOR-LD to JSON-LD Decoding Algorithm</h3>
         <p>
 This algorithm takes a CBOR-LD payload `cborldBytes`, and returns a JSON-LD document `jsonldDocument`.
         </p>

--- a/index.html
+++ b/index.html
@@ -556,12 +556,12 @@ To register an entry, follow the instructions in <a href="https://github.com/jso
   <section class="normative">
     <h1>Algorithms</h1>
 In this section, we specify the algorithms required to convert JSON-LD to CBOR-LD
-and vice versa. We provide first the context processing algorithms, which are required
-for both decompression and compression; we then provide the mode-specific algorithms.
-    <section>
+and vice versa. The majority of the algorithms in this section relate to the semantic
+compression feature and are not used in conversions between CBOR-LD and JSON-LD where
+the CBOR-LD payload does not use semantic compression.
       <h2>Encoding and Decoding</h2>
       <section>
-        <h3>JSON-LD to CBOR-LD Compression Algorithm</h3>
+        <h3>JSON-LD to CBOR-LD Algorithm</h3>
         <p>
 This algorithm takes a map `typeTable`, an integer `registryEntryId`, and a JSON-LD
 document `jsonldDocument` as inputs, and returns a hexadecimal string `cborldBytes`.
@@ -575,25 +575,31 @@ Set `prefix` to the result of passing `registryEntryId` to
 Set `state` to an empty map.
           </li>
           <li>
+If the registry entry associated with `registryEntryId` requires semantic compression:
+          <ol>
+            <li>
 Set `state.strategy` to "compression".
-          </li>
-          <li>
+            </li>
+            <li>
 Set `state.typeTable` to `typeTable`.
-          </li>
-          <li>
+            </li>
+            <li>
 Set `state.registryEntryId` to `registryEntryId`.
-          </li>
-          <li>
+            </li>
+            <li>
 Set `state` to the result of passing `state` to
 <a href="#initialize-conversion-algorithm"></a>.
-          </li>
-          <li>
+            </li>
+            <li>
 Set `output` to the result of passing `state` and `jsonldDocument`
 as `inputDocument` to <a href="#convert-document-algorithm"></a>.
-          </li>
-          <li>
+            </li>
+            <li>
 Set `suffix` to the CBOR encoding of `output`.
+            </li>
+          </ol>
           </li>
+Otherwise, set `suffix` to the CBOR encoding of `jsonldDocument`.
           <li>
 Set `cborldBytes` to a hexidecimal encoding of `prefix` prepended to `suffix`.
           </li>

--- a/index.html
+++ b/index.html
@@ -617,8 +617,8 @@ This algorithm takes a CBOR-LD payload `cborldBytes`, and returns a JSON-LD docu
         </p>
         <ol>
           <li>
-Set `result` to the result of passing `registryEntryId` and `cborldBytes` to
-<a href="#get-cbor-tag-structure-algorithm"></a>.
+Set `result` to the result of passing `cborldBytes` to
+<a href="#get-registry-entry-id-algorithm"></a>.
           </li>
           <li>
 Set `state`.`registryEntryId` to `result`.`registryEntryId` and `suffix` to `result`.`suffix`.
@@ -627,25 +627,32 @@ Set `state`.`registryEntryId` to `result`.`registryEntryId` and `suffix` to `res
 Set `state` to an empty map.
           </li>
           <li>
+If the registry entry associated with `state`.`registryEntryId` uses semantic compression:
+          <ol>
+            <li>
 Set `state.strategy` to "decompression".
-          </li>
-          <li>
+            </li>
+            <li>
 For each entry <em>`type`: `map`</em> in the `typeTables` array in the CBOR-LD Varint Registry Entry
 associated with `registryEntryId`, add that entry to `state`.`typeTable`, and set the value of `type`
 in `state`.`reverseTypeTable` to `inverseMap`, where `inverseMap` is `map` with the mapping inverted.
-          </li>
-          <li>
+            </li>
+            <li>
 Set `state` to the result of passing `state` to
 <a href="#initialize-conversion-algorithm"></a>.
-          </li>
-          <li>
+            </li>
+            <li>
 Set `input` to the result of decoding `suffix` from bytes to a map.
-          </li>
-          <li>
+            </li>
+            <li>
 Set `jsonldDocument` to the result of passing `state` and `input` as `inputDocuments`
 to <a href="#convert-document-algorithm"></a>.
+            </li>
+          </ol>
           </li>
-
+          <li>
+Otherwise, set `jsonldDocument` to the result of parsing `cborldBytes`.
+          </li>
           <li>
 Return `jsonldDocument`.
           </li>

--- a/index.html
+++ b/index.html
@@ -599,7 +599,9 @@ Set `suffix` to the CBOR encoding of `output`.
             </li>
           </ol>
           </li>
+          <li>
 Otherwise, set `suffix` to the CBOR encoding of `jsonldDocument`.
+          </li>
           <li>
 Set `cborldBytes` to a hexidecimal encoding of `prefix` prepended to `suffix`.
           </li>
@@ -649,7 +651,6 @@ Return `jsonldDocument`.
           </li>
         </ol>
       </section>
-    </section>
     <section>
       <h2>Conversion Algorithms</h2>
       <p>


### PR DESCRIPTION
Currently the top-level encoding/decoding algorithms JSON-LD <-> CBOR-LD always use (or expect) semantic compression, which is not representative of the ways CBOR-LD can be used (registry entry 0 does not use semantic compression, for example).

This PR adds checks to those top-level algorithm that determine if the passed registry entry/payload uses semantic compression or not and changes the encoding/decoding appropriately.

Partially addresses #60.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wes-smith/cbor-ld-spec/pull/61.html" title="Last updated on Mar 25, 2026, 3:23 PM UTC (0d89618)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cbor-ld/61/2dc3502...wes-smith:0d89618.html" title="Last updated on Mar 25, 2026, 3:23 PM UTC (0d89618)">Diff</a>