### PR TITLE
docs: add links to JSON-LD spec(s)

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@
   <p>
 CBOR is a compact binary data serialization and messaging format. This
 specification defines CBOR-LD 1.0, a CBOR-based format to serialize Linked Data.
-The encoding is designed to leverage the existing JSON-LD ecosystem, which is
+The encoding is designed to leverage the existing [[[JSON-LD11]]] ecosystem, which is
 deployed on hundreds of millions of systems today, to provide a compact
 serialization format for those seeking efficient encoding schemes for Linked
 Data. By utilizing semantic compression schemes, compression ratios in excess of
@@ -266,7 +266,7 @@ capable of demonstrating the features described in this document.
   <p>
 CBOR is a compact binary data serialization and messaging format. This
 specification defines CBOR-LD 1.0, a CBOR-based format to serialize Linked Data.
-The encoding is designed to leverage the existing JSON-LD ecosystem, which is
+The encoding is designed to leverage the existing [[[JSON-LD11]]] ecosystem, which is
 deployed on hundreds of millions of systems today, to provide a compact
 serialization format for those seeking efficient encoding schemes for Linked
 Data. By utilizing semantic compression schemes, compression ratios in excess of
@@ -285,7 +285,7 @@ protocols, and to efficiently store Linked Data in CBOR-based storage engines.
     <ul>
       <li>Software developers who want to encode Linked Data in a variety of
         programming languages that can use CBOR</li>
-      <li>Software developers who want to convert existing JSON-LD to CBOR-LD</li>
+      <li>Software developers who want to convert existing [[[JSON-LD11]]] to CBOR-LD</li>
       <li>Software developers who want to understand the design decisions and
         language syntax for CBOR-LD</li>
       <li>Software developers who want to implement processors and APIs for
@@ -340,7 +340,7 @@ protocols, and to efficiently store Linked Data in CBOR-based storage engines.
     <dl>
       <dt>Simplicity</dt>
       <dd>
-Implementations should be simple to implement given an existing JSON-LD
+Implementations should be simple to implement given an existing [[[JSON-LD11]]]
 implementation.
       </dd>
       <dt>Efficient Storage</dt>
@@ -414,7 +414,7 @@ Scoped contexts are the most challenging aspect of a more generalized solution.
 The deeper the algorithm has to understand scoping, the more combinatorial the
 problem becomes and thus the more possible compression values there are, which
 harms compression size. The trick is to leverage the determinism in the existing
-JSON-LD Processing algorithms and take shortcuts only when it won't affect
+[[[JSON-LD11-API]]] Processing algorithms and take shortcuts only when it won't affect
 JSON-LD processing.
       </li>
     </ul>
@@ -426,7 +426,7 @@ JSON-LD processing.
     <h1>Basic Concept</h1>
 
     <p>
-The general CBOR-LD encoding algorithm takes a JSON-LD Document and does
+The general CBOR-LD encoding algorithm takes a [[[JSON-LD11]]] Document and does
 the following:
     </p>
 
@@ -555,7 +555,7 @@ To register an entry, follow the instructions in <a href="https://github.com/jso
   </section>
   <section class="normative">
     <h1>Algorithms</h1>
-In this section, we specify the algorithms required to convert JSON-LD to CBOR-LD
+In this section, we specify the algorithms required to convert [[[JSON-LD11]]] to CBOR-LD
 and vice versa. The majority of the algorithms in this section relate to the semantic
 compression feature and are not used in conversions between CBOR-LD and JSON-LD where
 the CBOR-LD payload does not use semantic compression.
@@ -1326,14 +1326,14 @@ Return `objectTypes`.
       <h2>Active Context Processing</h2>
         <p>
 The algorithms in this section describe how to determine
-what components of the context documents associated with a JSON-LD
+what components of the context documents associated with a [[[JSON-LD11]]]
 document are in use at any point during compression or decompression.
 These algorithms include how to apply embedded, type-scoped, and
 property-scoped contexts with CBOR-LD. This is in contrast to the Context
 Loading algorithms defined later in this specification, which describe how
 to construct the mappings from terms to integers that are the core CBOR-LD
 compression technique. Together, the Active Context Processing and Context
-Loading algorithms specify how JSON-LD context documents should be processed
+Loading algorithms specify how [[[JSON-LD11]]] context documents should be processed
 when converting to and from CBOR-LD.
         </p>
         <section>
@@ -1873,7 +1873,7 @@ Return `result`.
     <section>
       <h2>Codecs</h2>
       <p>
-The codecs in this section specify exactly how individual values in JSON-LD should be converted to CBOR
+The codecs in this section specify exactly how individual values in [[[JSON-LD11]]] should be converted to CBOR
 and vice versa. They are used by the algorithms in the previous section, and allow CBOR-LD to efficiently
 encode both primitive and non-primitive types as CBOR.
       </p>


### PR DESCRIPTION
## Summary

Adds spec links to prose references of JSON-LD throughout the document, addressing #55.

- Uses respec `[[[JSON-LD11]]]` triple-bracket references to link first mentions of "JSON-LD" per major section to the [JSON-LD 1.1](https://www.w3.org/TR/json-ld11/) specification
- Links "JSON-LD Processing algorithms" specifically to `[[[JSON-LD11-API]]]` ([JSON-LD 1.1 Processing Algorithms and API](https://www.w3.org/TR/json-ld11-api/))
- Sections updated: Abstract, Introduction, How to Read this Document, Design Goals, Basic Concept, Algorithms, Active Context Processing, and Codecs

Only first mentions per section are linked, following standard W3C editorial practice. No prose was rewritten.

Fixes #55

---

🇺🇸 Reid Wiseman — Commander
🇺🇸 Victor Glover — Pilot
🇺🇸 Christina Koch — Mission Specialist
🇨🇦 Jeremy Hansen — Mission Specialist

Artemis II. Open standards for all — on this planet and beyond it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jw409/cbor-ld/pull/69.html" title="Last updated on Apr 1, 2026, 11:56 PM UTC (702ad3c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cbor-ld/69/0b0affb...jw409:702ad3c.html" title="Last updated on Apr 1, 2026, 11:56 PM UTC (702ad3c)">Diff</a>