### PR TITLE
docs: update IANA Considerations with current registration links

### DIFF
--- a/index.html
+++ b/index.html
@@ -2241,7 +2241,9 @@ Return `result`.
       <h2>CBOR Tag</h2>
       <p>
 This specification registers a CBOR tag to allow consumers to identify CBOR-LD payloads.
-<b>The following is provisional, and has not yet been ratified by IANA.</b>
+The registration can be found in
+<a href='https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml'>the IANA CBOR Tags registry</a>
+(<a href='https://www.iana.org/assignments/cbor-tags/template/51997'>template</a>).
       </p>
       <p>
 <b>Tag</b>: 51997

--- a/index.html
+++ b/index.html
@@ -2242,8 +2242,8 @@ Return `result`.
       <p>
 This specification registers a CBOR tag to allow consumers to identify CBOR-LD payloads.
 The registration can be found in
-<a href='https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml'>the IANA CBOR Tags registry</a>
-(<a href='https://www.iana.org/assignments/cbor-tags/template/51997'>template</a>).
+<a href="https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml">the IANA CBOR Tags registry</a>
+(<a href="https://www.iana.org/assignments/cbor-tags/template/51997">template</a>).
       </p>
       <p>
 <b>Tag</b>: 51997


### PR DESCRIPTION
## Summary

CBOR tag 51997 was registered with IANA on 2025-05-05, but the IANA Considerations section still carried a bold "provisional" warning stating the registration had not yet been ratified. This PR:

- Removes the outdated provisional warning
- Adds direct links to the [IANA CBOR Tags registry](https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml) and the [tag 51997 registration template](https://www.iana.org/assignments/cbor-tags/template/51997)

**Note**: The IANA registration template itself still references the old spec URL (`json-ld.github.io/cbor-ld-spec/`) rather than the current `w3c.github.io/cbor-ld/`. Updating that requires a separate request to IANA. This PR ensures the spec-side section is accurate and links directly to the registration.

Partially addresses #56

---

🇺🇸 Reid Wiseman — Commander
🇺🇸 Victor Glover — Pilot
🇺🇸 Christina Koch — Mission Specialist
🇨🇦 Jeremy Hansen — Mission Specialist

Artemis II. Open standards for all — on this planet and beyond it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jw409/cbor-ld/pull/70.html" title="Last updated on Apr 3, 2026, 9:02 PM UTC (49cc815)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cbor-ld/70/0b0affb...jw409:49cc815.html" title="Last updated on Apr 3, 2026, 9:02 PM UTC (49cc815)">Diff</a>