### PR TITLE
docs: add selective links to JSON-LD spec(s)

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@
   <p>
 CBOR is a compact binary data serialization and messaging format. This
 specification defines CBOR-LD 1.0, a CBOR-based format to serialize Linked Data.
-The encoding is designed to leverage the existing <a data-cite="JSON-LD11">JSON-LD</a> ecosystem, which is
+The encoding is designed to leverage the existing <a data-cite="JSON-LD11#">JSON-LD</a> ecosystem, which is
 deployed on hundreds of millions of systems today, to provide a compact
 serialization format for those seeking efficient encoding schemes for Linked
 Data. By utilizing semantic compression schemes, compression ratios in excess of
@@ -266,7 +266,7 @@ capable of demonstrating the features described in this document.
   <p>
 CBOR is a compact binary data serialization and messaging format. This
 specification defines CBOR-LD 1.0, a CBOR-based format to serialize Linked Data.
-The encoding is designed to leverage the existing <a data-cite="JSON-LD11">JSON-LD</a> ecosystem, which is
+The encoding is designed to leverage the existing <a data-cite="JSON-LD11#">JSON-LD</a> ecosystem, which is
 deployed on hundreds of millions of systems today, to provide a compact
 serialization format for those seeking efficient encoding schemes for Linked
 Data. By utilizing semantic compression schemes, compression ratios in excess of
@@ -325,7 +325,7 @@ protocols, and to efficiently store Linked Data in CBOR-based storage engines.
     <h2>Terminology</h2>
 
     <p>This document uses the following terms as defined in external specifications
-      and defines terms specific to <a data-cite="JSON-LD11">JSON-LD</a>.</p>
+      and defines terms specific to <a data-cite="JSON-LD11#">JSON-LD</a>.</p>
 
     <div data-include="common/terms.html"
          data-oninclude="restrictReferences">
@@ -414,7 +414,7 @@ Scoped contexts are the most challenging aspect of a more generalized solution.
 The deeper the algorithm has to understand scoping, the more combinatorial the
 problem becomes and thus the more possible compression values there are, which
 harms compression size. The trick is to leverage the determinism in the existing
-<a data-cite="JSON-LD11-API">JSON-LD Processing algorithms</a> and take shortcuts only when it won't affect
+<a data-cite="JSON-LD11-API#">JSON-LD Processing algorithms</a> and take shortcuts only when it won't affect
 JSON-LD processing.
       </li>
     </ul>

--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@
   <p>
 CBOR is a compact binary data serialization and messaging format. This
 specification defines CBOR-LD 1.0, a CBOR-based format to serialize Linked Data.
-The encoding is designed to leverage the existing JSON-LD ecosystem, which is
+The encoding is designed to leverage the existing <a data-cite="JSON-LD11">JSON-LD</a> ecosystem, which is
 deployed on hundreds of millions of systems today, to provide a compact
 serialization format for those seeking efficient encoding schemes for Linked
 Data. By utilizing semantic compression schemes, compression ratios in excess of
@@ -266,7 +266,7 @@ capable of demonstrating the features described in this document.
   <p>
 CBOR is a compact binary data serialization and messaging format. This
 specification defines CBOR-LD 1.0, a CBOR-based format to serialize Linked Data.
-The encoding is designed to leverage the existing JSON-LD ecosystem, which is
+The encoding is designed to leverage the existing <a data-cite="JSON-LD11">JSON-LD</a> ecosystem, which is
 deployed on hundreds of millions of systems today, to provide a compact
 serialization format for those seeking efficient encoding schemes for Linked
 Data. By utilizing semantic compression schemes, compression ratios in excess of
@@ -325,7 +325,7 @@ protocols, and to efficiently store Linked Data in CBOR-based storage engines.
     <h2>Terminology</h2>
 
     <p>This document uses the following terms as defined in external specifications
-      and defines terms specific to JSON-LD.</p>
+      and defines terms specific to <a data-cite="JSON-LD11">JSON-LD</a>.</p>
 
     <div data-include="common/terms.html"
          data-oninclude="restrictReferences">
@@ -414,7 +414,7 @@ Scoped contexts are the most challenging aspect of a more generalized solution.
 The deeper the algorithm has to understand scoping, the more combinatorial the
 problem becomes and thus the more possible compression values there are, which
 harms compression size. The trick is to leverage the determinism in the existing
-JSON-LD Processing algorithms and take shortcuts only when it won't affect
+<a data-cite="JSON-LD11-API">JSON-LD Processing algorithms</a> and take shortcuts only when it won't affect
 JSON-LD processing.
       </li>
     </ul>


### PR DESCRIPTION
## Summary

Adds spec links to key first-mentions of JSON-LD, addressing #55.

Uses respec `data-cite` attributes to preserve readable prose while linking to the relevant specifications:

- **Abstract** (first mention): links "JSON-LD" → [JSON-LD 1.1](https://www.w3.org/TR/json-ld11/)
- **Introduction** (first mention in body): same
- **Terminology** ("terms specific to JSON-LD"): links to JSON-LD 1.1 — reader entry point for definitions
- **Design Goals** ("JSON-LD Processing algorithms"): links to [JSON-LD 1.1 API](https://www.w3.org/TR/json-ld11-api/) — distinct spec

All other mentions (35 of 39 total) are left as plain text, since "JSON-LD" reads naturally as a term and doesn't need repeated linking.

This replaces the earlier #69 which was rightly flagged as too aggressive with inline references.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jw408/cbor-ld/pull/72.html" title="Last updated on Apr 3, 2026, 8:52 PM UTC (32591e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cbor-ld/72/88717ef...jw408:32591e4.html" title="Last updated on Apr 3, 2026, 8:52 PM UTC (32591e4)">Diff</a>