### PR TITLE
fix bug in 'CBOR-LD to JSON-LD decoding'

### DIFF
--- a/index.html
+++ b/index.html
@@ -632,14 +632,14 @@ This algorithm takes a CBOR-LD payload `cborldBytes`, and returns a JSON-LD docu
         </p>
         <ol>
           <li>
+Set `state` to an empty map.
+          </li>
+          <li>
 Set `result` to the result of passing `cborldBytes` to
 <a href="#get-registry-entry-id-algorithm"></a>.
           </li>
           <li>
 Set `state`.`registryEntryId` to `result`.`registryEntryId` and `suffix` to `result`.`suffix`.
-          </li>
-          <li>
-Set `state` to an empty map.
           </li>
           <li>
 If the registry entry associated with `state`.`registryEntryId` uses semantic compression:


### PR DESCRIPTION
setting `state` to an empty map at step 3 overrides the setting of `state.registryEntryId` at step 2. Fix: move the initialization of `state` before anything else


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/cbor-ld/pull/86.html" title="Last updated on Jul 2, 2026, 11:52 AM UTC (6e64f7b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cbor-ld/86/a9b17e1...6e64f7b.html" title="Last updated on Jul 2, 2026, 11:52 AM UTC (6e64f7b)">Diff</a>