### PR TITLE
fix signature for Convert Document Algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -714,7 +714,7 @@ Return `state`.
         <p>
 This algorithm takes a map `state` and a map or array of
 maps `inputDocuments`, and returns a map or
-array of maps `outputMaps`.
+array of maps `outputMaps`, respectively.
         </p>
         <ol>
           <li>

--- a/index.html
+++ b/index.html
@@ -713,7 +713,7 @@ Return `state`.
         <h3>Convert Document Algorithm</h3>
         <p>
 This algorithm takes a map `state` and a map or array of
-maps `inputDocuments`, and returns a map containing a map `state` and a map or
+maps `inputDocuments`, and returns a map or
 array of maps `outputMaps`.
         </p>
         <ol>


### PR DESCRIPTION
the current signature is not consistent with either
* the algorithm itself (only `outputMaps` or its unique element is returned)
* the two sites were the algorithm is called (only `outputMaps` is used)

NB: it is also not clear why this algorithm accepts an array of maps. It seems to be only called twice, twice with a single document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/cbor-ld/pull/89.html" title="Last updated on Jul 16, 2026, 8:53 AM UTC (c012dc3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cbor-ld/89/a9b17e1...c012dc3.html" title="Last updated on Jul 16, 2026, 8:53 AM UTC (c012dc3)">Diff</a>