### PR TITLE
termInfo.definition is never used

### DIFF
--- a/index.html
+++ b/index.html
@@ -1051,10 +1051,10 @@ If `activeContext`.`termMap` has an entry for `key`, set `definition` to the val
 `activeContext`.`termMap`. Otherwise, set `definition` to an empty map.
                 </li>
                 <li>
-Set `entryTerm` to be a new map.
+Set `entryTerm` to be a new map.Update index.html
                 </li>
                 <li>
-Set the value of "term" in `entryTerm` to be the value of `key`. Add `termId`, `plural`, and `definition`
+Set the value of "term" in `entryTerm` to be the value of `key`. Set the value of "def" in `entryTerm` to be the value of `definition`. Add `termId`, and `plural`
 to `entryTerm`.
                 </li>
                 <li>
@@ -1233,7 +1233,7 @@ Set `definition` to the value of `term` in `activeContext`.`termMap`.
 Set `entryTerm` to be a new map.
                 </li>
                 <li>
-Set the value of "termId" in `entryTerm` to be the value of `key`. Add `term`, `plural`, and `definition`
+Set the value of "termId" in `entryTerm` to be the value of `key`. Set the value of "def" in `entryTerm` to be the value of `definition`. Add `term`, and `plural`
 to `entryTerm`.
                 </li>
                 <li>
@@ -1306,7 +1306,7 @@ Set `definition` to the value of `term` in `activeContext`.`termMap`.
 Set `termInfo` to be a new map.
                 </li>
                 <li>
-Add `term`, `termId`, `plural`, and `definition` to `termInfo`.
+Set the value of "def" in `entryTerm` to be the value of `definition`. Add `term`, `termId`, and `plural` to `termInfo`.
                 </li>
                 <li>
 If `value` is not an array, set `values` to be an array containing as a single element `value`.

--- a/index.html
+++ b/index.html
@@ -1051,7 +1051,7 @@ If `activeContext`.`termMap` has an entry for `key`, set `definition` to the val
 `activeContext`.`termMap`. Otherwise, set `definition` to an empty map.
                 </li>
                 <li>
-Set `entryTerm` to be a new map.Update index.html
+Set `entryTerm` to be a new map.
                 </li>
                 <li>
 Set the value of "term" in `entryTerm` to be the value of `key`. Set the value of "def" in `entryTerm` to be the value of `definition`. Add `termId`, and `plural`


### PR DESCRIPTION
but termInfo.def is used multiple times.
This changes the 3 places where a termInfo is initialized, to be consistent with how it is used.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/cbor-ld/pull/100.html" title="Last updated on Jul 16, 2026, 7:18 AM UTC (ecdfb0a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cbor-ld/100/a8ed441...ecdfb0a.html" title="Last updated on Jul 16, 2026, 7:18 AM UTC (ecdfb0a)">Diff</a>