### PR TITLE
typo: id→key in Get Input Entries for Decompression

### DIFF
--- a/index.html
+++ b/index.html
@@ -1217,11 +1217,11 @@ Otherwise:
 If `key` is odd, set `plural` to true. Otherwise, set `plural` to false.
                     </li>
                     <li>
-If `plural` is `true`, set `term` to the value of `id` minus 1 in `state`.`idToTerm`.
+If `plural` is `true`, set `term` to the value of `key` minus 1 in `state`.`idToTerm`.
 If that value does not have an entry, throw an error ERR_UNKNOWN_CBORLD_TERM_ID.
                     </li>
                     <li>
-Otherwise, set `term` to the value of `id` in `state`.`idToTerm`. If that value does not have
+Otherwise, set `term` to the value of `key` in `state`.`idToTerm`. If that value does not have
 an entry, throw an error ERR_UNKNOWN_CBORLD_TERM_ID.
                     </li>
                   </ol>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/cbor-ld/pull/106.html" title="Last updated on Jul 17, 2026, 7:05 AM UTC (a85cd28)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cbor-ld/106/843fb52...a85cd28.html" title="Last updated on Jul 17, 2026, 7:05 AM UTC (a85cd28)">Diff</a>